### PR TITLE
broker: subscriptions persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can find the complete build and installation instructions for each component
 
 * JAVA 8
 * Maven 2 (for build)
+* OS/CPU supported by [Sqlite-JDBC](https://github.com/xerial/sqlite-jdbc) (for cepheus-broker)
 
 ### Build via Maven
 

--- a/cepheus-broker/deb/init.d/cepheus-broker.sh
+++ b/cepheus-broker/deb/init.d/cepheus-broker.sh
@@ -16,9 +16,10 @@ PID_PATH_NAME=/tmp/cepheus-broker-pid
 
 CONFIG=/etc/cepheus/broker.properties
 LOG=/var/log/cepheus/broker.log
+DATA=/var/run/cepheus/cepheus-broker.db
 PORT=8081
 
-ARGS="--spring.config.location=$CONFIG --logging.mode=file --logging.file=$LOG --port=$PORT"
+ARGS="--spring.config.location=$CONFIG --spring.datasource.url=jdbc:sqlite:$DATA --logging.mode=file --logging.file=$LOG --port=$PORT"
 
 case $1 in
     start)

--- a/cepheus-broker/pom.xml
+++ b/cepheus-broker/pom.xml
@@ -21,6 +21,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -41,6 +45,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+        </dependency>
+        <!-- persistence -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
         </dependency>
         <!-- log -->
         <dependency>

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/Subscriptions.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/Subscriptions.java
@@ -50,7 +50,7 @@ public class Subscriptions {
         try {
             subscriptions = subscriptionsRepository.getAllSubscriptions();
         } catch (SubscriptionPersistenceException e) {
-            logger.error("Failed to load subscriptions", e);
+            logger.error("Failed to load subscriptions from database", e);
         }
     }
 
@@ -87,7 +87,7 @@ public class Subscriptions {
         try {
             subscriptionsRepository.saveSubscription(subscription);
         } catch (SubscriptionPersistenceException e) {
-            throw new SubscriptionException("Impossible to save subscription", e);
+            logger.error("Failed to save subscription into database", e);
         }
 
         return subscriptionId;
@@ -101,7 +101,11 @@ public class Subscriptions {
     public boolean deleteSubscription(UnsubscribeContext unsubscribeContext) {
         String subscriptionId = unsubscribeContext.getSubscriptionId();
         Subscription subscription = subscriptions.remove(subscriptionId);
-        subscriptionsRepository.removeSubscription(subscriptionId);
+        try {
+            subscriptionsRepository.removeSubscription(subscriptionId);
+        } catch (SubscriptionPersistenceException e) {
+            logger.error("Failed to remove subscription from database", e);
+        }
         return (subscription != null);
     }
 
@@ -141,7 +145,11 @@ public class Subscriptions {
         subscriptions.forEach((subscriptionId, subscribeContext) -> {
             if (subscribeContext.getExpirationDate().isBefore(now)) {
                 subscriptions.remove(subscriptionId);
-                subscriptionsRepository.removeSubscription(subscriptionId);
+                try {
+                    subscriptionsRepository.removeSubscription(subscriptionId);
+                } catch (SubscriptionPersistenceException e) {
+                    logger.error("Failed to remove subscription from database", e);
+                }
             }
         });
     }

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/Subscriptions.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/Subscriptions.java
@@ -31,7 +31,7 @@ import java.util.regex.PatternSyntaxException;
 @Component
 public class Subscriptions {
 
-    private Map<String, SubscribeContext> subscriptions = new ConcurrentHashMap<>();
+    private Map<String, SubscribeContext> subscriptions;
 
     @Autowired
     private Patterns patterns;
@@ -50,7 +50,7 @@ public class Subscriptions {
      * @return the subscriptionId
      * @throws SubscriptionException
      */
-    public String addSubscription(SubscribeContext subscribeContext) throws SubscriptionException{
+    public String addSubscription(SubscribeContext subscribeContext) throws SubscriptionException {
         //if duration is not present, then lb set duration to P1M
         Duration duration = convertDuration(subscribeContext.getDuration());
         if (duration.isNegative()) {

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
@@ -14,6 +14,7 @@ import com.orange.cepheus.broker.Subscriptions;
 import com.orange.cepheus.broker.exception.MissingRemoteBrokerException;
 import com.orange.cepheus.broker.exception.RegistrationException;
 import com.orange.cepheus.broker.exception.SubscriptionException;
+import com.orange.cepheus.broker.exception.SubscriptionPersistenceException;
 import com.orange.cepheus.broker.model.Subscription;
 import com.orange.ngsi.client.NgsiClient;
 import com.orange.ngsi.model.*;
@@ -159,7 +160,7 @@ public class NgsiController extends NgsiBaseController {
     }
 
     @Override
-    public SubscribeContextResponse subscribeContext(final SubscribeContext subscribe) throws SubscriptionException {
+    public SubscribeContextResponse subscribeContext(final SubscribeContext subscribe) throws SubscriptionException, SubscriptionPersistenceException {
         logger.debug("<= subscribeContext on entities: {}", subscribe.getEntityIdList().toString());
 
         SubscribeContextResponse subscribeContextResponse = new SubscribeContextResponse();
@@ -176,7 +177,7 @@ public class NgsiController extends NgsiBaseController {
     }
 
     @Override
-    public UnsubscribeContextResponse unsubscribeContext(final UnsubscribeContext unsubscribe) {
+    public UnsubscribeContextResponse unsubscribeContext(final UnsubscribeContext unsubscribe) throws SubscriptionPersistenceException {
         logger.debug("<= unsubscribeContext with subscriptionId: {}", unsubscribe.getSubscriptionId());
 
         String subscriptionId = unsubscribe.getSubscriptionId();
@@ -219,6 +220,17 @@ public class NgsiController extends NgsiBaseController {
         statusCode.setCode("400");
         statusCode.setReasonPhrase("subscription error");
         statusCode.setDetail(subscriptionException.getMessage());
+        return errorResponse(req.getRequestURI(), statusCode);
+    }
+
+    @ExceptionHandler(SubscriptionPersistenceException.class)
+    public ResponseEntity<Object> subscriptionPersistenceExceptionHandler(HttpServletRequest req, SubscriptionPersistenceException subscriptionPersistenceException) {
+        logger.error("SubscriptionPersistenceException error: {}", subscriptionPersistenceException.getMessage());
+
+        StatusCode statusCode = new StatusCode();
+        statusCode.setCode("500");
+        statusCode.setReasonPhrase("error in subscription persistence");
+        statusCode.setDetail(subscriptionPersistenceException.getMessage());
         return errorResponse(req.getRequestURI(), statusCode);
     }
 

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
@@ -14,6 +14,7 @@ import com.orange.cepheus.broker.Subscriptions;
 import com.orange.cepheus.broker.exception.MissingRemoteBrokerException;
 import com.orange.cepheus.broker.exception.RegistrationException;
 import com.orange.cepheus.broker.exception.SubscriptionException;
+import com.orange.cepheus.broker.model.Subscription;
 import com.orange.ngsi.client.NgsiClient;
 import com.orange.ngsi.model.*;
 import com.orange.ngsi.server.NgsiBaseController;
@@ -107,12 +108,12 @@ public class NgsiController extends NgsiBaseController {
             logger.warn("No local.url parameter defined to use as originator for sending notifyContext");
         } else {
             // Send notifications to matching subscriptions
-            Iterator<SubscribeContext> matchingSubscriptions = subscriptions.findSubscriptions(contextElement.getEntityId(), attributesName);
+            Iterator<Subscription> matchingSubscriptions = subscriptions.findSubscriptions(contextElement.getEntityId(), attributesName);
             while (matchingSubscriptions.hasNext()) {
-                SubscribeContext subscribeContext = matchingSubscriptions.next();
-                NotifyContext notifyContext = new NotifyContext(subscribeContext.getSubscriptionId(), new URI(originator));
+                Subscription subscription = matchingSubscriptions.next();
+                NotifyContext notifyContext = new NotifyContext(subscription.getSubscriptionId(), new URI(originator));
                 notifyContext.setContextElementResponseList(contextElementResponseList);
-                String providerUrl = subscribeContext.getReference().toString();
+                String providerUrl = subscription.getSubscribeContext().getReference().toString();
 
                 HttpHeaders httpHeaders = ngsiClient.getRequestHeaders(providerUrl);
                 logger.debug("=> notifyContext to {} with Content-Type {}", providerUrl, httpHeaders.getContentType());
@@ -168,7 +169,7 @@ public class NgsiController extends NgsiBaseController {
         String subscriptionId = subscriptions.addSubscription(subscribe);
         subscribeResponse.setSubscriptionId(subscriptionId);
         //return in the response the duration because it is set by the subscriptions class if the duration is null in the request
-        subscribeResponse.setDuration(subscriptions.getSubscription(subscriptionId).getDuration());
+        subscribeResponse.setDuration(subscriptions.getSubscription(subscriptionId).getSubscribeContext().getDuration());
         subscribeContextResponse.setSubscribeResponse(subscribeResponse);
 
         return subscribeContextResponse;

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/exception/SubscriptionPersistenceException.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/exception/SubscriptionPersistenceException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.cepheus.broker.exception;
+
+/**
+ * Exception that can occur during the persistence of subscription.
+ */
+public class SubscriptionPersistenceException extends Exception {
+    public SubscriptionPersistenceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/exception/SubscriptionPersistenceException.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/exception/SubscriptionPersistenceException.java
@@ -15,4 +15,8 @@ public class SubscriptionPersistenceException extends Exception {
     public SubscriptionPersistenceException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public SubscriptionPersistenceException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/model/Subscription.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/model/Subscription.java
@@ -1,0 +1,50 @@
+package com.orange.cepheus.broker.model;
+
+import com.orange.ngsi.model.SubscribeContext;
+
+import java.time.Instant;
+
+/**
+ * Created by pborscia on 13/10/2015.
+ */
+public class Subscription {
+
+    String subscriptionId;
+
+    Instant expirationDate;
+
+    SubscribeContext subscribeContext;
+
+    public Subscription() {
+    }
+
+    public Subscription(String subscriptionId, Instant expirationDate, SubscribeContext subscribeContext) {
+        this.subscriptionId = subscriptionId;
+        this.expirationDate = expirationDate;
+        this.subscribeContext = subscribeContext;
+    }
+
+    public void setSubscriptionId(String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public Instant getExpirationDate() {
+        return expirationDate;
+    }
+
+    public void setExpirationDate(Instant expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public SubscribeContext getSubscribeContext() {
+        return subscribeContext;
+    }
+
+    public void setSubscribeContext(SubscribeContext subscribeContext) {
+        this.subscribeContext = subscribeContext;
+    }
+}

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/persistence/SubscriptionsRepository.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/persistence/SubscriptionsRepository.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.cepheus.broker.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.orange.ngsi.model.SubscribeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Repository for Subscriptions
+ */
+@Repository
+public class SubscriptionsRepository {
+    private static Logger logger = LoggerFactory.getLogger(SubscriptionsRepository.class);
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
+
+    private static class Subscription {
+        String subscriptionId;
+        String subscribeContextString;
+
+        public Subscription() {
+        }
+
+        public void setSubscriptionId(String subscriptionId) {
+            this.subscriptionId = subscriptionId;
+        }
+
+        public void setSubscribeContextString(String subscribeContextString) {
+            this.subscribeContextString = subscribeContextString;
+        }
+
+        public String getSubscriptionId() {
+            return subscriptionId;
+        }
+
+        public String getSubscribeContextString() {
+            return subscribeContextString;
+        }
+    }
+
+    /**
+     * Save a subscription.
+     * @param subscriptionId
+     * @param subscribeContext
+     * @throws JsonProcessingException
+     */
+    public void saveSubscription(String subscriptionId, SubscribeContext subscribeContext) throws JsonProcessingException {
+        //serialization
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectWriter writer = mapper.writer(new DefaultPrettyPrinter());
+        String susbcribeContextString = writer.writeValueAsString(subscribeContext);
+
+        jdbcTemplate.update("insert into t_subscriptions(id,subscribeContext) values(?,?)", subscriptionId, susbcribeContextString);
+    }
+
+    /**
+     * Save a subscription updated
+     * @param subscriptionId
+     * @param subscribeContext
+     * @throws JsonProcessingException
+     */
+    public void updateSubscription(String subscriptionId, SubscribeContext subscribeContext) throws JsonProcessingException {
+        //serialization
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectWriter writer = mapper.writer();
+        String susbcribeContextString = writer.writeValueAsString(subscribeContext);
+
+        jdbcTemplate.update("update t_subscriptions set subscribeContext=? where id=?", susbcribeContextString, subscriptionId);
+    }
+
+    /**
+     * Get all subscriptions saved
+     * @return subscriptions map
+     */
+    public Map<String, SubscribeContext> getAllSubscriptions() {
+        Map<String, SubscribeContext> subscriptions = new ConcurrentHashMap<>();
+        List<Subscription> subscriptionList = jdbcTemplate.query( "select id, subscribeContext from t_subscriptions", new SubscriptionMapper());
+        ObjectMapper mapper = new ObjectMapper();
+        subscriptionList.forEach(subscription -> {
+            try {
+                SubscribeContext subscribeContext = mapper.readValue(subscription.getSubscribeContextString(), SubscribeContext.class);
+                subscriptions.put(subscription.getSubscriptionId(), subscribeContext);
+            } catch (IOException e) {
+                logger.warn("failed to get subscription {}", subscription.getSubscribeContextString());
+            }
+        });
+        return subscriptions;
+    }
+
+    /**
+     * Remove a subscription.
+     * @param subscriptionId
+     */
+    public void removeSubscription(String subscriptionId) {
+        jdbcTemplate.update("delete from t_subscriptions where id=?", subscriptionId);
+    }
+
+    private static final class SubscriptionMapper implements RowMapper<Subscription> {
+
+        public Subscription mapRow(ResultSet rs, int rowNum) throws SQLException {
+            Subscription subscription = new Subscription();
+            subscription.setSubscriptionId(rs.getString("id"));
+            subscription.setSubscribeContextString(rs.getString("subscribeContext"));
+            return subscription;
+        }
+    }
+
+}

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/persistence/SubscriptionsRepository.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/persistence/SubscriptionsRepository.java
@@ -20,6 +20,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
+import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -59,6 +60,12 @@ public class SubscriptionsRepository {
         public String getSubscribeContextString() {
             return subscribeContextString;
         }
+    }
+
+    @PostConstruct
+    protected void createTableOnStartup() {
+        jdbcTemplate.execute("create table if not exists t_subscriptions (id varchar, subscribeContext varchar)");
+        jdbcTemplate.execute("create unique index if not exists index_subscriptionId on t_subscriptions (id)");
     }
 
     /**

--- a/cepheus-broker/src/main/resources/application.properties
+++ b/cepheus-broker/src/main/resources/application.properties
@@ -20,3 +20,8 @@ logging.file=${java.io.tmpdir:-/tmp}/cepheus-broker.log
 
 # Disable Spring Boot endpoints
 endpoints.enabled=false
+
+# Datasource configuration for the Subscriptions persistence
+spring.datasource.driverClassName=org.sqlite.JDBC
+spring.datasource.url=jdbc:sqlite:${java.io.tmpdir:-/tmp}/cepheus-broker.db
+

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/SubscriptionsTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/SubscriptionsTest.java
@@ -141,7 +141,7 @@ public class SubscriptionsTest {
     }
 
     @Test
-    public void deleteNotExistSubscriptions() throws URISyntaxException, SubscriptionException {
+    public void deleteNotExistSubscriptions() throws URISyntaxException, SubscriptionException, SubscriptionPersistenceException {
         UnsubscribeContext unsubscribeContext = new UnsubscribeContext("12345");
         assertFalse(subscriptions.deleteSubscription(unsubscribeContext));
     }

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/controller/NgsiControllerTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/controller/NgsiControllerTest.java
@@ -14,6 +14,7 @@ import com.orange.cepheus.broker.LocalRegistrations;
 import com.orange.cepheus.broker.Subscriptions;
 import com.orange.cepheus.broker.exception.RegistrationException;
 import com.orange.cepheus.broker.exception.SubscriptionException;
+import com.orange.cepheus.broker.model.Subscription;
 import com.orange.ngsi.client.NgsiClient;
 import com.orange.ngsi.model.*;
 import org.junit.After;
@@ -34,6 +35,8 @@ import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
@@ -79,7 +82,7 @@ public class NgsiControllerTest {
     Iterator<URI> providingApplication;
 
     @Mock
-    Iterator<SubscribeContext> matchedSubscriptions;
+    Iterator<Subscription> matchedSubscriptions;
 
     @Mock
     ListenableFuture<UpdateContextResponse> updateContextResponseListenableFuture;
@@ -273,8 +276,8 @@ public class NgsiControllerTest {
         //subscriptions mock return always with matched subscriptions
         when(matchedSubscriptions.hasNext()).thenReturn(true, false);
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("999999");
-        when(matchedSubscriptions.next()).thenReturn(subscribeContext);
+        Subscription subscription = new Subscription("999999", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        when(matchedSubscriptions.next()).thenReturn(subscription);
         when(subscriptions.findSubscriptions(any(), any())).thenReturn(matchedSubscriptions);
 
         //ngsiclient mock return always createUpdateContextREsponseTemperature when call updateContext
@@ -342,8 +345,8 @@ public class NgsiControllerTest {
         //subscriptions mock return always with matched subscriptions
         when(matchedSubscriptions.hasNext()).thenReturn(true, false);
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("999999");
-        when(matchedSubscriptions.next()).thenReturn(subscribeContext);
+        Subscription subscription = new Subscription("999999", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        when(matchedSubscriptions.next()).thenReturn(subscription);
         when(subscriptions.findSubscriptions(any(), any())).thenReturn(matchedSubscriptions);
 
         //ngsiclient mock return always createUpdateContextREsponseTemperature when call updateContext
@@ -411,8 +414,8 @@ public class NgsiControllerTest {
         //subscriptions mock return always with matched subscriptions
         when(matchedSubscriptions.hasNext()).thenReturn(true, false);
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("999999");
-        when(matchedSubscriptions.next()).thenReturn(subscribeContext);
+        Subscription subscription = new Subscription("999999", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        when(matchedSubscriptions.next()).thenReturn(subscription);
         when(subscriptions.findSubscriptions(any(), any())).thenReturn(matchedSubscriptions);
 
         //ngsiclient mock return always createUpdateContextREsponseTemperature when call updateContext
@@ -481,8 +484,8 @@ public class NgsiControllerTest {
         //subscriptions mock return always with matched subscriptions
         when(matchedSubscriptions.hasNext()).thenReturn(true, false);
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("999999");
-        when(matchedSubscriptions.next()).thenReturn(subscribeContext);
+        Subscription subscription = new Subscription("999999", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        when(matchedSubscriptions.next()).thenReturn(subscription);
         when(subscriptions.findSubscriptions(any(), any())).thenReturn(matchedSubscriptions);
 
         //ngsiclient mock return always createUpdateContextREsponseTemperature when call updateContext
@@ -543,8 +546,8 @@ public class NgsiControllerTest {
         //subscriptions mock return always with matched subscriptions
         when(matchedSubscriptions.hasNext()).thenReturn(true, false);
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("999999");
-        when(matchedSubscriptions.next()).thenReturn(subscribeContext);
+        Subscription subscription = new Subscription("999999", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        when(matchedSubscriptions.next()).thenReturn(subscription);
         when(subscriptions.findSubscriptions(any(), any())).thenReturn(matchedSubscriptions);
 
         //ngsiclient mock return always createUpdateContextREsponseTemperature when call updateContext
@@ -1077,9 +1080,9 @@ public class NgsiControllerTest {
     public void postNewSubscribeContext() throws Exception {
 
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-
+        Subscription subscription = new Subscription("12345678", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
         when(subscriptions.addSubscription(any())).thenReturn("12345678");
-        when(subscriptions.getSubscription("12345678")).thenReturn(subscribeContext);
+        when(subscriptions.getSubscription("12345678")).thenReturn(subscription);
 
         mockMvc.perform(post("/v1/subscribeContext")
                 .content(json(mapper, subscribeContext))
@@ -1099,9 +1102,9 @@ public class NgsiControllerTest {
         subscribeContext.setDuration(null);
 
         SubscribeContext subscribeContextInSubscription = createSubscribeContextTemperature();
-
+        Subscription subscription = new Subscription("12345678", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContextInSubscription);
         when(subscriptions.addSubscription(any())).thenReturn("12345678");
-        when(subscriptions.getSubscription("12345678")).thenReturn(subscribeContextInSubscription);
+        when(subscriptions.getSubscription("12345678")).thenReturn(subscription);
 
         mockMvc.perform(post("/v1/subscribeContext")
                 .content(json(mapper, subscribeContext))

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
@@ -10,6 +10,8 @@ package com.orange.cepheus.broker.persistence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.orange.cepheus.broker.Application;
+import com.orange.cepheus.broker.exception.SubscriptionPersistenceException;
+import com.orange.cepheus.broker.model.Subscription;
 import com.orange.ngsi.model.SubscribeContext;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,61 +53,55 @@ public class SubscriptionsRepositoryTest {
     }
 
     @Test
-    public void saveSubscriptionTest() throws URISyntaxException, JsonProcessingException {
+    public void saveSubscriptionTest() throws URISyntaxException, SubscriptionPersistenceException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("12345");
-        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.saveSubscription("12345", subscribeContext);
-        Map<String, SubscribeContext> subscriptions = subscriptionsRepository.getAllSubscriptions();
+        Subscription subscription = new Subscription("12345", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        subscriptionsRepository.saveSubscription(subscription);
+        Map<String, Subscription> subscriptions = subscriptionsRepository.getAllSubscriptions();
         Assert.assertEquals(1, subscriptions.size());
-        Assert.assertEquals(subscribeContext.getSubscriptionId(), subscriptions.get("12345").getSubscriptionId());
-        Assert.assertEquals(subscribeContext.getExpirationDate(), subscriptions.get("12345").getExpirationDate());
-        Assert.assertEquals(subscribeContext.getDuration(), subscriptions.get("12345").getDuration());
+        Assert.assertEquals(subscription.getSubscriptionId(), subscriptions.get("12345").getSubscriptionId());
+        Assert.assertEquals(subscription.getExpirationDate(), subscriptions.get("12345").getExpirationDate());
+        Assert.assertEquals(subscribeContext.getDuration(), subscriptions.get("12345").getSubscribeContext().getDuration());
     }
 
     @Test
-    public void updateSubscriptionTest() throws URISyntaxException, JsonProcessingException {
+    public void updateSubscriptionTest() throws URISyntaxException, SubscriptionPersistenceException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("12345");
-        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.saveSubscription("12345", subscribeContext);
-        Map<String, SubscribeContext> subscriptions = subscriptionsRepository.getAllSubscriptions();
+        Subscription subscription = new Subscription("12345", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        subscriptionsRepository.saveSubscription(subscription);
+        Map<String, Subscription> subscriptions = subscriptionsRepository.getAllSubscriptions();
         Assert.assertEquals(1, subscriptions.size());
-        Assert.assertEquals("P1M", subscriptions.get("12345").getDuration());
+        Assert.assertEquals("P1M", subscriptions.get("12345").getSubscribeContext().getDuration());
         subscribeContext.setDuration("PT1D");
-        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.updateSubscription("12345", subscribeContext);
+        subscription.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
+        subscriptionsRepository.updateSubscription(subscription);
         subscriptions = subscriptionsRepository.getAllSubscriptions();
         Assert.assertEquals(1, subscriptions.size());
-        Assert.assertEquals("PT1D", subscriptions.get("12345").getDuration());
-        Assert.assertEquals(subscribeContext.getExpirationDate(), subscriptions.get("12345").getExpirationDate());
+        Assert.assertEquals("PT1D", subscriptions.get("12345").getSubscribeContext().getDuration());
+        Assert.assertEquals(subscription.getExpirationDate(), subscriptions.get("12345").getExpirationDate());
     }
 
     @Test
-    public void removeSubscriptionTest() throws URISyntaxException, JsonProcessingException {
+    public void removeSubscriptionTest() throws URISyntaxException, SubscriptionPersistenceException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("12345");
-        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        Subscription subscription = new Subscription("12345", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        subscriptionsRepository.saveSubscription(subscription);
         Assert.assertEquals(1, subscriptionsRepository.getAllSubscriptions().size());
         subscriptionsRepository.removeSubscription("12345");
         Assert.assertEquals(0, subscriptionsRepository.getAllSubscriptions().size());
     }
 
     @Test
-    public void getAllSubscriptionsTest() throws URISyntaxException, JsonProcessingException {
+    public void getAllSubscriptionsTest() throws URISyntaxException, SubscriptionPersistenceException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
-        subscribeContext.setSubscriptionId("12345");
-        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        Subscription subscription = new Subscription("12345", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext);
+        subscriptionsRepository.saveSubscription(subscription);
         SubscribeContext subscribeContext2 = createSubscribeContextTemperature();
-        subscribeContext2.setSubscriptionId("12346");
-        subscribeContext2.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.saveSubscription("12346", subscribeContext);
+        Subscription subscription2 = new Subscription("12346", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext2);
+        subscriptionsRepository.saveSubscription(subscription2);
         SubscribeContext subscribeContext3 = createSubscribeContextTemperature();
-        subscribeContext3.setSubscriptionId("12347");
-        subscribeContext3.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
-        subscriptionsRepository.saveSubscription("12347", subscribeContext);
+        Subscription subscription3 = new Subscription("12347", Instant.now().plus(1, ChronoUnit.DAYS), subscribeContext3);
+        subscriptionsRepository.saveSubscription(subscription3);
         Assert.assertEquals(3, subscriptionsRepository.getAllSubscriptions().size());
     }
 

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
@@ -23,8 +23,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.net.URISyntaxException;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 
@@ -35,7 +33,7 @@ import static com.orange.cepheus.broker.Util.createSubscribeContextTemperature;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)
-//@TestPropertySource(locations="classpath:test.properties")
+@TestPropertySource(locations="classpath:test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class SubscriptionsRepositoryTest {
 
@@ -47,13 +45,7 @@ public class SubscriptionsRepositoryTest {
 
     @Before
     public void init() throws SQLException {
-        /*DatabaseMetaData md = jdbcTemplate.getDataSource().getConnection().getMetaData();
-        ResultSet rs = md.getTables(null, null, "t_subscriptions", null);
-        if (rs.next()) {
-            jdbcTemplate.execute("drop table t_subscriptions");
-        }*/
-        jdbcTemplate.execute("drop table if exists t_subscriptions");
-        jdbcTemplate.execute("create table t_subscriptions (id varchar, subscribeContext varchar)");
+        jdbcTemplate.execute("delete from t_subscriptions");
     }
 
     @Test

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
@@ -24,6 +24,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import static com.orange.cepheus.broker.Util.createSubscribeContextTemperature;
@@ -51,30 +53,39 @@ public class SubscriptionsRepositoryTest {
     @Test
     public void saveSubscriptionTest() throws URISyntaxException, JsonProcessingException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscribeContext.setSubscriptionId("12345");
+        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.saveSubscription("12345", subscribeContext);
         Map<String, SubscribeContext> subscriptions = subscriptionsRepository.getAllSubscriptions();
         Assert.assertEquals(1, subscriptions.size());
+        Assert.assertEquals(subscribeContext.getSubscriptionId(), subscriptions.get("12345").getSubscriptionId());
+        Assert.assertEquals(subscribeContext.getExpirationDate(), subscriptions.get("12345").getExpirationDate());
         Assert.assertEquals(subscribeContext.getDuration(), subscriptions.get("12345").getDuration());
     }
 
     @Test
     public void updateSubscriptionTest() throws URISyntaxException, JsonProcessingException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscribeContext.setSubscriptionId("12345");
+        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.saveSubscription("12345", subscribeContext);
         Map<String, SubscribeContext> subscriptions = subscriptionsRepository.getAllSubscriptions();
         Assert.assertEquals(1, subscriptions.size());
         Assert.assertEquals("P1M", subscriptions.get("12345").getDuration());
-        subscribeContext.setDuration("PT10S");
+        subscribeContext.setDuration("PT1D");
+        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.updateSubscription("12345", subscribeContext);
         subscriptions = subscriptionsRepository.getAllSubscriptions();
         Assert.assertEquals(1, subscriptions.size());
-        Assert.assertEquals("PT10S", subscriptions.get("12345").getDuration());
-
+        Assert.assertEquals("PT1D", subscriptions.get("12345").getDuration());
+        Assert.assertEquals(subscribeContext.getExpirationDate(), subscriptions.get("12345").getExpirationDate());
     }
 
     @Test
     public void removeSubscriptionTest() throws URISyntaxException, JsonProcessingException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscribeContext.setSubscriptionId("12345");
+        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.saveSubscription("12345", subscribeContext);
         Assert.assertEquals(1, subscriptionsRepository.getAllSubscriptions().size());
         subscriptionsRepository.removeSubscription("12345");
@@ -84,8 +95,16 @@ public class SubscriptionsRepositoryTest {
     @Test
     public void getAllSubscriptionsTest() throws URISyntaxException, JsonProcessingException {
         SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscribeContext.setSubscriptionId("12345");
+        subscribeContext.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        SubscribeContext subscribeContext2 = createSubscribeContextTemperature();
+        subscribeContext2.setSubscriptionId("12346");
+        subscribeContext2.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.saveSubscription("12346", subscribeContext);
+        SubscribeContext subscribeContext3 = createSubscribeContextTemperature();
+        subscribeContext3.setSubscriptionId("12347");
+        subscribeContext3.setExpirationDate(Instant.now().plus(1, ChronoUnit.DAYS));
         subscriptionsRepository.saveSubscription("12347", subscribeContext);
         Assert.assertEquals(3, subscriptionsRepository.getAllSubscriptions().size());
     }

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/persistence/SubscriptionsRepositoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.cepheus.broker.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.orange.cepheus.broker.Application;
+import com.orange.ngsi.model.SubscribeContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.net.URISyntaxException;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static com.orange.cepheus.broker.Util.createSubscribeContextTemperature;
+
+/**
+ * Tests for SubscriptionsRepository
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+//@TestPropertySource(locations="classpath:test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class SubscriptionsRepositoryTest {
+
+    @Autowired
+    SubscriptionsRepository subscriptionsRepository;
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
+
+    @Before
+    public void init() throws SQLException {
+        /*DatabaseMetaData md = jdbcTemplate.getDataSource().getConnection().getMetaData();
+        ResultSet rs = md.getTables(null, null, "t_subscriptions", null);
+        if (rs.next()) {
+            jdbcTemplate.execute("drop table t_subscriptions");
+        }*/
+        jdbcTemplate.execute("drop table if exists t_subscriptions");
+        jdbcTemplate.execute("create table t_subscriptions (id varchar, subscribeContext varchar)");
+    }
+
+    @Test
+    public void saveSubscriptionTest() throws URISyntaxException, JsonProcessingException {
+        SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        Map<String, SubscribeContext> subscriptions = subscriptionsRepository.getAllSubscriptions();
+        Assert.assertEquals(1, subscriptions.size());
+        Assert.assertEquals(subscribeContext.getDuration(), subscriptions.get("12345").getDuration());
+    }
+
+    @Test
+    public void updateSubscriptionTest() throws URISyntaxException, JsonProcessingException {
+        SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        Map<String, SubscribeContext> subscriptions = subscriptionsRepository.getAllSubscriptions();
+        Assert.assertEquals(1, subscriptions.size());
+        Assert.assertEquals("P1M", subscriptions.get("12345").getDuration());
+        subscribeContext.setDuration("PT10S");
+        subscriptionsRepository.updateSubscription("12345", subscribeContext);
+        subscriptions = subscriptionsRepository.getAllSubscriptions();
+        Assert.assertEquals(1, subscriptions.size());
+        Assert.assertEquals("PT10S", subscriptions.get("12345").getDuration());
+
+    }
+
+    @Test
+    public void removeSubscriptionTest() throws URISyntaxException, JsonProcessingException {
+        SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        Assert.assertEquals(1, subscriptionsRepository.getAllSubscriptions().size());
+        subscriptionsRepository.removeSubscription("12345");
+        Assert.assertEquals(0, subscriptionsRepository.getAllSubscriptions().size());
+    }
+
+    @Test
+    public void getAllSubscriptionsTest() throws URISyntaxException, JsonProcessingException {
+        SubscribeContext subscribeContext = createSubscribeContextTemperature();
+        subscriptionsRepository.saveSubscription("12345", subscribeContext);
+        subscriptionsRepository.saveSubscription("12346", subscribeContext);
+        subscriptionsRepository.saveSubscription("12347", subscribeContext);
+        Assert.assertEquals(3, subscriptionsRepository.getAllSubscriptions().size());
+    }
+
+}

--- a/cepheus-broker/src/test/resources/test.properties
+++ b/cepheus-broker/src/test/resources/test.properties
@@ -13,3 +13,5 @@ remote.servicePath=gateway1
 
 # remote broker OAuth token for secured brokers
 remote.authToken=XXXXXXXXX
+
+spring.datasource.url=jdbc:sqlite::memory:

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/SubscribeContext.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/SubscribeContext.java
@@ -50,12 +50,6 @@ public class SubscribeContext {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String throttling;
 
-    @JsonIgnore
-    private Instant expirationDate;
-
-    @JsonIgnore
-    private String subscriptionId;
-
     public SubscribeContext() {
     }
 
@@ -113,22 +107,6 @@ public class SubscribeContext {
 
     public void setThrottling(String throttling) {
         this.throttling = throttling;
-    }
-
-    public Instant getExpirationDate() {
-        return expirationDate;
-    }
-
-    public void setExpirationDate(Instant expirationDate) {
-        this.expirationDate = expirationDate;
-    }
-
-    public String getSubscriptionId() {
-        return subscriptionId;
-    }
-
-    public void setSubscriptionId(String subscriptionId) {
-        this.subscriptionId = subscriptionId;
     }
 
     @Override

--- a/doc/admin/broker.md
+++ b/doc/admin/broker.md
@@ -94,6 +94,7 @@ This is a short list of the application properties:
     <tr><td>remote.servicePath</td><td>remote broker Service Path</td><td></td></tr>
     <tr><td>remote.authToken</td><td>OAuth token for secured broker</td><td></td></tr>
     <tr><td>logging.level.com.orange.cepheus.broker</td><td>log level</td><td>INFO</td></tr>
+    <tr><td>spring.datasource.url</td><td>DataBase url</td><td>jdbc:sqlite:${java.io.tmpdir:-/tmp}/cepheus-broker.db</td></tr>
 </table>
 
 

--- a/doc/admin/broker.md
+++ b/doc/admin/broker.md
@@ -4,6 +4,7 @@ This is the administrative guide to Cepheus-Broker.
 
 * JAVA 8
 * Maven 2 (for building only)
+* OS/CPU supported by [Sqlite-JDBC](https://github.com/xerial/sqlite-jdbc)
 
 ## Building from source
 

--- a/doc/broker/index.md
+++ b/doc/broker/index.md
@@ -10,6 +10,8 @@ This keeps the implementation simple and sufficient for the use cases handled by
 The main goal of the Cepheus-broker is to sit between the IoT Agents or NGSI devices, forward their requests to a remote NGSI broker (like Orion)
 while allowing other NGSI components to subscribe to some the the updated Context Elements.
 
+The broker persists the subscriptions not only on memory but also on Sqlite database.
+ 
 ![broker](../fig/broker.png)
 
 # Forwarding support
@@ -41,7 +43,7 @@ The broker has many limitations due to its simple design compared to a complete 
 - Broker only supports `registerContext`, `updateContext`, `queryContext`, `subscribeContext`, `unsubscribeContext` and `notifyContext` operations from NGSI v1 API (json formated).
 - Subscriptions only support `ONCHANGE` as type of notification.
 - Subscriptions do not handle throttling.
-- All subscriptions and registrations are lost on restart of the application (not persisted on disk, kept in memory only).
+- All registrations are lost on restart of the application (not persisted on disk, kept in memory only).
 - If multiple NGSI providers register the same Context Entities, only the first provider will get the forwarded `queryContext` or `updateContext` requests.
 - When a `queryContext` or `updateContext` request contains references to multiple Context Entities, the request is forwarded only to the Context Provider of the first Context Entity.
 - Broker does not keep the any value of Context Entities, all requests will get forwarded to a Context Provider or the remote Broker.

--- a/doc/broker/index.md
+++ b/doc/broker/index.md
@@ -10,7 +10,7 @@ This keeps the implementation simple and sufficient for the use cases handled by
 The main goal of the Cepheus-broker is to sit between the IoT Agents or NGSI devices, forward their requests to a remote NGSI broker (like Orion)
 while allowing other NGSI components to subscribe to some the the updated Context Elements.
 
-The broker persists the subscriptions not only on memory but also on Sqlite database.
+The broker persists the subscriptions on Sqlite database.
  
 ![broker](../fig/broker.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <properties>
         <java.version>1.8</java.version>
         <jackson-annotations-version>2.6.0</jackson-annotations-version>
+        <spring-boot-version>1.2.3.RELEASE</spring-boot-version>
         <jacoco.dataPath>${project.basedir}/target/jacoco.exec</jacoco.dataPath>
         <jacoco.reportPath>${project.basedir}/../coverage</jacoco.reportPath>
     </properties>
@@ -31,13 +32,18 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <type>pom</type>
-                <version>1.2.3.RELEASE</version>
+                <version>${spring-boot-version}</version>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
-                <version>1.2.3.RELEASE</version>
+                <version>${spring-boot-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-jdbc</artifactId>
+                <version>${spring-boot-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -90,6 +96,12 @@
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
                 <scope>test</scope>
+            </dependency>
+            <!-- persistence -->
+            <dependency>
+                <groupId>org.xerial</groupId>
+                <artifactId>sqlite-jdbc</artifactId>
+                <version>3.8.11.2</version>
             </dependency>
             <!-- log -->
             <dependency>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,7 @@ curl -L -o cepheus-broker.jar "http://oss.sonatype.org/service/local/artifact/ma
 
 # launch Cepheus-CEP and Cepheus-Broker
 nohup java -jar -Djava.security.egd=file:/dev/./urandom cepheus-cep.jar --logging.config=file --logging.file=cep.log --port=8080 2>> /dev/null >> /dev/null &
-nohup java -jar -Djava.security.egd=file:/dev/./urandom cepheus-broker.jar --logging.config=file --logging.file=broker.log --port=8081 2>> /dev/null >> /dev/null &
+nohup java -jar -Djava.security.egd=file:/dev/./urandom cepheus-broker.jar --spring.datasource.url=jdbc:sqlite:cepheus-broker.db --logging.config=file --logging.file=broker.log --port=8081 2>> /dev/null >> /dev/null &
 
 
 


### PR DESCRIPTION
The subscriptions are persisted even if the broker crashs.
The subscriptions are persisted in Sqlite database.
The Sqlite binary is embedded in the cepheus-broker software.
The admin can configure the url of database by using the property 'spring.datasource.url'. By default, its value is ${java.io.tmpdir:-/tmp}/cepheus-broker.db.