### PR TITLE
 broker: filter forwarded requests

### DIFF
--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/Configuration.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/Configuration.java
@@ -48,6 +48,17 @@ public class Configuration {
     @Value("${remote.authToken:}")
     private String remoteAuthToken;
 
+    /**
+     * Disable forwarding updateContext requests to the remote broker
+     *
+     * All NGSI requests are forwarded by the Cepheus-Broker to the remote broker.
+     * Except:
+     *  - subscribeContext/updateContextSubscription/unsubscribeContext (handled by the app)
+     *  - updateContext (if
+     */
+    @Value("${remote.forward.updateContext:true}")
+    private boolean remoteForwardUpdateContext = true;
+
     public Configuration() {
     }
 
@@ -91,6 +102,14 @@ public class Configuration {
         this.remoteAuthToken = remoteAuthToken;
     }
 
+    public boolean isRemoteForwardUpdateContext() {
+        return remoteForwardUpdateContext;
+    }
+
+    public void setRemoteForwardUpdateContext(boolean remoteForwardUpdateContext) {
+        this.remoteForwardUpdateContext = remoteForwardUpdateContext;
+    }
+
     /*
      * Inject Orion-specific headers into the given HttpHeaders list
      * @param httpHeaders
@@ -115,6 +134,7 @@ public class Configuration {
                 ", remoteServiceName='" + remoteServiceName + '\'' +
                 ", remoteServicePath='" + remoteServicePath + '\'' +
                 ", remoteAuthToken='" + remoteAuthToken + '\'' +
+                ", remoteForwardUpdateContext=" + remoteForwardUpdateContext +
                 '}';
     }
 }

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/ConfigurationTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/ConfigurationTest.java
@@ -40,6 +40,7 @@ public class ConfigurationTest {
         assertEquals("gateway", configuration.getRemoteServiceName());
         assertEquals("gateway1", configuration.getRemoteServicePath());
         assertEquals("XXXXXXXXX", configuration.getRemoteAuthToken());
+        assertEquals(true, configuration.isRemoteForwardUpdateContext());
     }
 
     @Test
@@ -47,6 +48,7 @@ public class ConfigurationTest {
         configuration.setRemoteServiceName("SERVICE");
         configuration.setRemoteServicePath("PATH");
         configuration.setRemoteAuthToken("TOKEN");
+        configuration.setRemoteForwardUpdateContext(false);
 
         HttpHeaders httpHeaders = new HttpHeaders();
         configuration.addRemoteHeaders(httpHeaders);

--- a/cepheus-broker/src/test/resources/test.properties
+++ b/cepheus-broker/src/test/resources/test.properties
@@ -14,4 +14,7 @@ remote.servicePath=gateway1
 # remote broker OAuth token for secured brokers
 remote.authToken=XXXXXXXXX
 
+# forwading updateContext to remote broker
+remote.forward.updateContext=true
+
 spring.datasource.url=jdbc:sqlite::memory:

--- a/doc/admin/broker.md
+++ b/doc/admin/broker.md
@@ -94,6 +94,7 @@ This is a short list of the application properties:
     <tr><td>remote.serviceName</td><td>remote broker Service Name</td><td></td></tr>
     <tr><td>remote.servicePath</td><td>remote broker Service Path</td><td></td></tr>
     <tr><td>remote.authToken</td><td>OAuth token for secured broker</td><td></td></tr>
+    <tr><td>remote.forward.updateContext</td><td>updateContext forwarding to remote broker</td><td>true</td></tr>
     <tr><td>logging.level.com.orange.cepheus.broker</td><td>log level</td><td>INFO</td></tr>
     <tr><td>spring.datasource.url</td><td>DataBase url</td><td>jdbc:sqlite:${java.io.tmpdir:-/tmp}/cepheus-broker.db</td></tr>
 </table>

--- a/doc/broker/index.md
+++ b/doc/broker/index.md
@@ -7,26 +7,34 @@ The Cepheus-broker component is a lightweight broker only supporting two kinds o
 
 This keeps the implementation simple and sufficient for the use cases handled by the NGSI gateway.
 
-The main goal of the Cepheus-broker is to sit between the IoT Agents or NGSI devices, forward their requests to a remote NGSI broker (like Orion)
-while allowing other NGSI components to subscribe to some the the updated Context Elements.
+The main goal of the Cepheus-Broker is to sit between the "south components" like IoT Agents or NGSI devices (actuators and sensors), forward their requests to a remote broker (e.g. a "north component" like Orion)
+while allowing some other NGSI components (like the Cepheus-CEP) to subscribe to some the updated Context Elements.
 
-The broker persists the subscriptions on Sqlite database.
- 
 ![broker](../fig/broker.png)
 
 # Forwarding support
 
-Request forwarding is based on the fact that all NGSI components will register their Context Entities on startup.
+Request forwarding is based on the fact that south components (like IoT Agents and NGSI devices) will register their Context Entities on startup.
 
 The broker will track these `/registerContext` requests (keeping a list of all `providingApplication` URLs)
 before forwarding them back to the remote broker.
 
-Then when `/updateContext` or `/queryContext` requests arrive, they will be either forwarded to the remote broker if no `providingApplication` matches
-or forwarded to the corresponding `providingApplication`.
+Then when `/updateContext` or `/queryContext` requests arrive, they will be :
+ - either forwarded to south components when a matching `providingApplication` URL is found.
+ - else forwarded to the remote broker.
 
 ![broker forward](../fig/broker-forward.png)
 
 The forwarding process is described in the Fiware-Orion project documentation: [here](https://fiware-orion.readthedocs.org/en/develop/user/context_providers/index.html)
+
+### Disable updateContext forward to the remote broker
+
+In some complex scenarios, it might be useful to **hide** Context Entities updates emitted by "south components" like sensors from the remote broker
+for privacy, latency or security reasons.
+
+The forwarding of `updateContext` requests to the remote broker can be disabled
+by setting `remote.forward.updateContext` to `false`
+(see [admin guide](../admin/broker.md) for more details).
 
 # Pubsub support
 
@@ -36,14 +44,15 @@ This feature is mainly used by Cepheus-CEP to track updates to Context Entities.
 
 ![broker notify](../fig/broker-notify.png)
 
+The subscriptions are persisted in a Sqlite database.
+
 # Limitations
 
 The broker has many limitations due to its simple design compared to a complete broker implementation.
 
 - Broker only supports `registerContext`, `updateContext`, `queryContext`, `subscribeContext`, `unsubscribeContext` and `notifyContext` operations from NGSI v1 API (json formated).
-- Subscriptions only support `ONCHANGE` as type of notification.
-- Subscriptions do not handle throttling.
-- All registrations are lost on restart of the application (not persisted on disk, kept in memory only).
+- Subscriptions only support `ONCHANGE` as type of notification of `notifyCondition`.
+- Subscriptions do not supportt `throttling`, `restriction` or `condValues`.
 - If multiple NGSI providers register the same Context Entities, only the first provider will get the forwarded `queryContext` or `updateContext` requests.
 - When a `queryContext` or `updateContext` request contains references to multiple Context Entities, the request is forwarded only to the Context Provider of the first Context Entity.
 - Broker does not keep the any value of Context Entities, all requests will get forwarded to a Context Provider or the remote Broker.


### PR DESCRIPTION
Add option to disable forwarding of updateContext requests to the remote broker.

Currently all updateContext request comming from devices are forwarded to the remote broker by Cepheus-Broker by default.

This can now be controller by setting `remote.forward.updateContext` to `false`.

issue #10