### PR TITLE
Forward the Fiware Headers

### DIFF
--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/LocalRegistrations.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/LocalRegistrations.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -61,7 +62,7 @@ public class LocalRegistrations {
      * @param registerContext
      * @return contextRegistrationId
      */
-    public String updateRegistrationContext(RegisterContext registerContext) throws RegistrationException, RegistrationPersistenceException {
+    public String updateRegistrationContext(RegisterContext registerContext, FiwareHeaders fiwareHeaders) throws RegistrationException, RegistrationPersistenceException {
         Duration duration = registrationDuration(registerContext);
         String registrationId = registerContext.getRegistrationId();
 
@@ -105,7 +106,7 @@ public class LocalRegistrations {
         registrations.put(registrationId, registration);
 
         // Forward to remote broker
-        remoteRegistrations.registerContext(registerContext, registrationId);
+        remoteRegistrations.registerContext(registerContext, registrationId, fiwareHeaders);
 
         return registrationId;
     }

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/LocalRegistrationsTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/LocalRegistrationsTest.java
@@ -81,13 +81,13 @@ public class LocalRegistrationsTest {
     public void testRegistration() throws Exception {
 
         RegisterContext registerContext = createRegistrationContext();
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
         Assert.hasLength(registrationId);
         Registration registration = localRegistrations.getRegistration(registrationId);
         assertNotNull(registration);
         assertNotNull(registration.getExpirationDate());
 
-        verify(remoteRegistrations).registerContext(eq(registerContext), eq(registrationId));
+        verify(remoteRegistrations).registerContext(eq(registerContext), eq(registrationId), eq(null));
         verify(registrationsRepository).getRegistration(eq(registrationId));
         verify(registrationsRepository).saveRegistration(eq(registration));
     }
@@ -99,13 +99,13 @@ public class LocalRegistrationsTest {
         doThrow(RegistrationPersistenceException.class).when(registrationsRepository).saveRegistration(any());
 
         RegisterContext registerContext = createRegistrationContext();
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
         Assert.hasLength(registrationId);
         Registration registration = localRegistrations.getRegistration(registrationId);
         assertNotNull(registration);
         assertNotNull(registration.getExpirationDate());
 
-        verify(remoteRegistrations, never()).registerContext(eq(registerContext), eq(registrationId));
+        verify(remoteRegistrations, never()).registerContext(eq(registerContext), eq(registrationId), null);
         verify(registrationsRepository).getRegistration(eq(registrationId));
         verify(registrationsRepository).saveRegistration(eq(registration));
     }
@@ -121,14 +121,14 @@ public class LocalRegistrationsTest {
         reset(registrationsRepository);
         when(registrationsRepository.getRegistration(any())).thenReturn(registration);
 
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
         Assert.hasLength(registrationId);
         assertNotEquals("12345", registrationId);
         Registration registration2 = localRegistrations.getRegistration(registrationId);
         assertNotNull(registration2);
         assertNotNull(registration2.getExpirationDate());
 
-        verify(remoteRegistrations).registerContext(eq(registerContext), eq(registrationId));
+        verify(remoteRegistrations).registerContext(eq(registerContext), eq(registrationId), eq(null));
         verify(registrationsRepository).getRegistration(eq(registrationId));
         verify(registrationsRepository).updateRegistration(eq(registration));
     }
@@ -136,13 +136,13 @@ public class LocalRegistrationsTest {
     @Test
     public void testUnregisterWithZeroDuration() throws Exception {
         RegisterContext registerContext = createRegistrationContext();
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
 
         // Remove registration using a zero duration
         RegisterContext zeroDuration = createRegistrationContext();
         zeroDuration.setRegistrationId(registrationId);
         zeroDuration.setDuration("PT0S");
-        localRegistrations.updateRegistrationContext(zeroDuration);
+        localRegistrations.updateRegistrationContext(zeroDuration, null);
 
         Assert.isNull(localRegistrations.getRegistration(registrationId));
 
@@ -156,13 +156,13 @@ public class LocalRegistrationsTest {
         doThrow(RegistrationPersistenceException.class).when(registrationsRepository).removeRegistration(any());
 
         RegisterContext registerContext = createRegistrationContext();
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
 
         // Remove registration using a zero duration
         RegisterContext zeroDuration = createRegistrationContext();
         zeroDuration.setRegistrationId(registrationId);
         zeroDuration.setDuration("PT0S");
-        localRegistrations.updateRegistrationContext(zeroDuration);
+        localRegistrations.updateRegistrationContext(zeroDuration, null);
 
         Assert.isNull(localRegistrations.getRegistration(registrationId));
 
@@ -174,7 +174,7 @@ public class LocalRegistrationsTest {
     public void test1MonthDuration() throws Exception {
         RegisterContext registerContext = createRegistrationContext();
         registerContext.setDuration("P1M");
-        localRegistrations.updateRegistrationContext(registerContext);
+        localRegistrations.updateRegistrationContext(registerContext, null);
 
         Calendar c = (Calendar) Calendar.getInstance().clone();
         c.add(Calendar.MONTH, 1);
@@ -192,12 +192,12 @@ public class LocalRegistrationsTest {
 
         //TODO expect does not work on inner Exception
         try {
-            localRegistrations.updateRegistrationContext(registerContext);
+            localRegistrations.updateRegistrationContext(registerContext, null);
             fail("registration should fail on bad duration with RegistrationException");
         } catch (RegistrationException ex) {
         }
 
-        verify(remoteRegistrations, never()).registerContext(any(), any());
+        verify(remoteRegistrations, never()).registerContext(any(), any(), eq(null));
     }
 
     @Test
@@ -209,19 +209,19 @@ public class LocalRegistrationsTest {
 
         //TODO expect does not work on inner Exception
         try {
-            localRegistrations.updateRegistrationContext(registerContext);
+            localRegistrations.updateRegistrationContext(registerContext, null);
             fail("registration should fail on bad pattern with RegistrationException");
         } catch (RegistrationException ex) {
         }
 
-        verify(remoteRegistrations, never()).registerContext(any(), any());
+        verify(remoteRegistrations, never()).registerContext(any(), any(), eq(null));
     }
 
     @Test
     public void testRegistrationPurge() throws Exception {
         RegisterContext registerContext = createRegistrationContext();
         registerContext.setDuration("PT1S"); // 1 s only
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
 
         // Wait for expiration
         Thread.sleep(1500);
@@ -241,7 +241,7 @@ public class LocalRegistrationsTest {
 
         RegisterContext registerContext = createRegistrationContext();
         registerContext.setDuration("PT1S"); // 1 s only
-        String registrationId = localRegistrations.updateRegistrationContext(registerContext);
+        String registrationId = localRegistrations.updateRegistrationContext(registerContext, null);
 
         // Wait for expiration
         Thread.sleep(1500);
@@ -259,7 +259,7 @@ public class LocalRegistrationsTest {
     public void testFindEntityId() throws Exception {
         // Insert 3 localRegistrations
         for (String n : new String[]{"A", "B", "C"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"), null);
         }
 
         // Find B
@@ -274,11 +274,11 @@ public class LocalRegistrationsTest {
     public void testFindEntityIds() throws Exception {
         // Insert 3 localRegistrations
         for (String n : new String[]{"A", "B", "C"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"), null);
         }
         // Insert 3 more
         for (String n : new String[]{"A", "B", "C"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n + "2", "temp"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n + "2", "temp"), null);
         }
 
         // Find the two B
@@ -295,7 +295,7 @@ public class LocalRegistrationsTest {
     public void testFindEntityIdPattern() throws Exception {
         // Insert 3 localRegistrations
         for (String n : new String[]{"A", "B", "C"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"), null);
         }
 
         // Find A and B
@@ -312,11 +312,11 @@ public class LocalRegistrationsTest {
     public void testFindEntyIdAndAttribute() throws Exception {
         // Insert 3 localRegistrations
         for (String n : new String[]{"A", "B", "C"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp" + n));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp" + n), null);
         }
         // Add other A entities but with other attributes
-        localRegistrations.updateRegistrationContext(createRegistrationContext("A", "string", false, "http://AB", "tempB"));
-        localRegistrations.updateRegistrationContext(createRegistrationContext("A", "string", false, "http://AC", "tempC"));
+        localRegistrations.updateRegistrationContext(createRegistrationContext("A", "string", false, "http://AB", "tempB"), null);
+        localRegistrations.updateRegistrationContext(createRegistrationContext("A", "string", false, "http://AC", "tempC"), null);
 
         // Find only entity A with attr tempA
         EntityId searchedEntityId = new EntityId("A", "string", false);
@@ -332,7 +332,7 @@ public class LocalRegistrationsTest {
     public void testFindEntyIdAndAttributes() throws Exception {
         // Insert 2 localRegistrations only temp2 attr
         for (String n : new String[]{"A", "B"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp2"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp2"), null);
         }
         // Insert 1 registration with both temp2 & temp3 attrs
         for (String n : new String[]{"C"}) {
@@ -341,11 +341,11 @@ public class LocalRegistrationsTest {
             attrs.add(new ContextRegistrationAttribute("temp2", false));
             attrs.add(new ContextRegistrationAttribute("temp3", false));
             registerContext.getContextRegistrationList().get(0).setContextRegistrationAttributeList(attrs);
-            localRegistrations.updateRegistrationContext(registerContext);
+            localRegistrations.updateRegistrationContext(registerContext, null);
         }
         // Insert 2 localRegistrations only temp3
         for (String n : new String[]{"D", "E"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp3"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp3"), null);
         }
 
         // Find only entity with temp2 and temp3
@@ -362,7 +362,7 @@ public class LocalRegistrationsTest {
     public void testFindEntityIdNoMatch() throws Exception {
         // Insert 3 localRegistrations
         for (String n : new String[]{"A", "B", "C"}) {
-            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"));
+            localRegistrations.updateRegistrationContext(createRegistrationContext(n, "string", false, "http://" + n, "temp"), null);
         }
 
         EntityId searchedEntityId = new EntityId("D", "string", false);
@@ -380,7 +380,7 @@ public class LocalRegistrationsTest {
         for (String n : new String[]{"A", "B", "C"}) {
             RegisterContext registerContext = createRegistrationContext(n, "string", false, "http://"+n, "temp");
             registerContext.setDuration("PT1S");
-            localRegistrations.updateRegistrationContext(registerContext);
+            localRegistrations.updateRegistrationContext(registerContext, null);
         }
 
         // Wait for expiration

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/controller/NgsiController.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/controller/NgsiController.java
@@ -67,7 +67,7 @@ public class NgsiController extends NgsiBaseController {
     }
 
     @Override
-    public UpdateContextResponse updateContext(final UpdateContext update) throws TypeNotFoundException {
+    public UpdateContextResponse updateContext(final UpdateContext update, FiwareHeaders fiwareHeaders) throws TypeNotFoundException {
 
         logger.debug("updateContext incoming request: {}", update.toString());
 

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/FiwareHeaders.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/FiwareHeaders.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * Store the Fiware headers like Fiware-Service, Fiware-ServicePath and X-Auth-Token
+ */
+public class FiwareHeaders {
+
+    String fiwareService;
+    String fiwarePath;
+    String fiwareToken;
+
+    public FiwareHeaders() {
+    }
+
+    public FiwareHeaders(String fiwareService, String fiwarePath, String fiwareToken) {
+        this.fiwareService = fiwareService;
+        this.fiwarePath = fiwarePath;
+        this.fiwareToken = fiwareToken;
+    }
+
+    public String getFiwareService() {
+        return fiwareService;
+    }
+
+    public void setFiwareService(String fiwareService) {
+        this.fiwareService = fiwareService;
+    }
+
+    public String getFiwarePath() {
+        return fiwarePath;
+    }
+
+    public void setFiwarePath(String fiwarePath) {
+        this.fiwarePath = fiwarePath;
+    }
+
+    public String getFiwareToken() {
+        return fiwareToken;
+    }
+
+    public void setFiwareToken(String fiwareToken) {
+        this.fiwareToken = fiwareToken;
+    }
+
+    public void addToHttpHeaders(HttpHeaders httpHeaders) {
+        if (fiwareService != null) {
+            httpHeaders.set("Fiware-Service", fiwareService);
+        }
+        if (fiwarePath != null) {
+            httpHeaders.set("Fiware-ServicePath", fiwarePath);
+        }
+        if (fiwareToken != null) {
+            httpHeaders.set("X-Auth-Token", fiwareToken);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "FiwareHeaders{" +
+                "fiwareService='" + fiwareService + '\'' +
+                ", fiwarePath='" + fiwarePath + '\'' +
+                ", fiwareToken='" + fiwareToken + '\'' +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiBaseController.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiBaseController.java
@@ -20,7 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -51,14 +50,14 @@ public class NgsiBaseController {
     final public ResponseEntity<UpdateContextResponse> updateContextRequest(@RequestBody final UpdateContext updateContext, HttpServletRequest httpServletRequest) throws Exception {
         ngsiValidation.checkUpdateContext(updateContext);
         registerIntoDispatcher(httpServletRequest);
-        return new ResponseEntity<>(updateContext(updateContext), HttpStatus.OK);
+        return new ResponseEntity<>(updateContext(updateContext, getFiwareHeaders(httpServletRequest)), HttpStatus.OK);
     }
 
     @RequestMapping(value = "/registerContext", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     final public ResponseEntity<RegisterContextResponse> registerContextRequest(@RequestBody final RegisterContext registerContext, HttpServletRequest httpServletRequest) throws Exception {
         ngsiValidation.checkRegisterContext(registerContext);
         registerIntoDispatcher(httpServletRequest);
-        return new ResponseEntity<>(registerContext(registerContext), HttpStatus.OK);
+        return new ResponseEntity<>(registerContext(registerContext, getFiwareHeaders(httpServletRequest)), HttpStatus.OK);
     }
 
     @RequestMapping(value = "/subscribeContext", method = RequestMethod.POST, consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
@@ -86,7 +85,7 @@ public class NgsiBaseController {
     final public ResponseEntity<QueryContextResponse> queryContextRequest(@RequestBody final QueryContext queryContext, HttpServletRequest httpServletRequest) throws Exception {
         ngsiValidation.checkQueryContext(queryContext);
         registerIntoDispatcher(httpServletRequest);
-        return new ResponseEntity<>(queryContext(queryContext), HttpStatus.OK);
+        return new ResponseEntity<>(queryContext(queryContext, getFiwareHeaders(httpServletRequest)), HttpStatus.OK);
     }
 
     @ExceptionHandler({MissingRequestParameterException.class})
@@ -122,11 +121,11 @@ public class NgsiBaseController {
         throw new UnsupportedOperationException("notifyContext");
     }
 
-    protected UpdateContextResponse updateContext(final UpdateContext update) throws Exception {
+    protected UpdateContextResponse updateContext(final UpdateContext update, FiwareHeaders fiwareHeaders) throws Exception {
         throw new UnsupportedOperationException("updateContext");
     }
 
-    protected RegisterContextResponse registerContext(final RegisterContext register) throws Exception {
+    protected RegisterContextResponse registerContext(final RegisterContext register, FiwareHeaders fiwareHeaders) throws Exception {
         throw new UnsupportedOperationException("registerContext");
     }
 
@@ -142,7 +141,7 @@ public class NgsiBaseController {
         throw new UnsupportedOperationException("unsubscribeContext");
     }
 
-    protected QueryContextResponse queryContext(final QueryContext query) throws Exception {
+    protected QueryContextResponse queryContext(final QueryContext query, FiwareHeaders fiwareHeaders) throws Exception {
         throw new UnsupportedOperationException("queryContext");
     }
 
@@ -207,6 +206,23 @@ public class NgsiBaseController {
 
         if (accept != null && accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
             protocolRegistry.registerHost(uri, true);
+        }
+    }
+
+    /**
+     * Extract the Fiware Headers
+     * @param httpServletRequest the request
+     * @return fiwareHeader
+     */
+    private FiwareHeaders getFiwareHeaders(HttpServletRequest httpServletRequest) {
+        String fiwareService = httpServletRequest.getHeader("Fiware-Service");
+        String fiwarePath = httpServletRequest.getHeader("Fiware-ServicePath");
+        String fiwareToken = httpServletRequest.getHeader("X-Auth-Token");
+
+        if (fiwareService==null && fiwarePath==null && fiwareToken==null) {
+            return null;
+        } else {
+            return new FiwareHeaders(fiwareService, fiwarePath, fiwareToken);
         }
     }
 }

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/model/FiwareHeadersTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/model/FiwareHeadersTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * FiwareHeaders tests
+ */
+public class FiwareHeadersTest {
+
+    @Test
+    public void checkAddToHttpHeaders() {
+        FiwareHeaders fiwareHeaders = new FiwareHeaders("service", "path", "XXX");
+        HttpHeaders httpHeaders = new HttpHeaders();
+        fiwareHeaders.addToHttpHeaders(httpHeaders);
+        assertEquals("service", httpHeaders.get("Fiware-Service").get(0));
+        assertEquals("path", httpHeaders.get("Fiware-ServicePath").get(0));
+        assertEquals("XXX", httpHeaders.get("X-Auth-Token").get(0));
+    }
+
+    @Test
+    public void checkToString() {
+        FiwareHeaders fiwareHeaders = new FiwareHeaders("service", "path", "XXX");
+        assertEquals("FiwareHeaders{fiwareService='service', fiwarePath='path', fiwareToken='XXX'}", fiwareHeaders.toString());
+    }
+}

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeControllerHelper.java
@@ -14,12 +14,12 @@ public class FakeControllerHelper extends NgsiBaseController {
     }
 
     @Override
-    protected UpdateContextResponse updateContext(UpdateContext update) throws Exception {
+    protected UpdateContextResponse updateContext(UpdateContext update, FiwareHeaders fiwareHeaders) throws Exception {
         return new UpdateContextResponse();
     }
 
     @Override
-    protected RegisterContextResponse registerContext(RegisterContext register) throws Exception {
+    protected RegisterContextResponse registerContext(RegisterContext register, FiwareHeaders fiwareHeaders) throws Exception {
         return new RegisterContextResponse();
     }
 
@@ -39,7 +39,7 @@ public class FakeControllerHelper extends NgsiBaseController {
     }
 
     @Override
-    protected QueryContextResponse queryContext(final QueryContext query) throws Exception {
+    protected QueryContextResponse queryContext(final QueryContext query, FiwareHeaders fiwareHeaders) throws Exception {
         return new QueryContextResponse();
     }
 

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiBaseControllerTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiBaseControllerTest.java
@@ -144,6 +144,15 @@ public class NgsiBaseControllerTest {
     public void checkUpdateContextImplemented() throws Exception {
         mockMvc.perform(post("/i/updateContext")
                 .content(json(jsonConverter, createUpdateContextTempSensor(0)))
+                .contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON)
+                .header("Fiware-Service", "gateway").header("Fiware-ServicePath", "gateway1").header("X-Auth-Token", "XXXXXX"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void checkUpdateContextImplementedWithNullFiwareHeaders() throws Exception {
+        mockMvc.perform(post("/i/updateContext")
+                .content(json(jsonConverter, createUpdateContextTempSensor(0)))
                 .contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
@@ -152,12 +161,22 @@ public class NgsiBaseControllerTest {
     public void checkUpdateContextImplementedInXml() throws Exception {
         mockMvc.perform(post("/i/updateContext")
                 .content(xmlmapper.writeValueAsString(createUpdateContextTempSensor(0)))
-                .contentType(MediaType.APPLICATION_XML).header("Host", "localhost").accept(MediaType.APPLICATION_XML))
+                .contentType(MediaType.APPLICATION_XML).header("Host", "localhost").accept(MediaType.APPLICATION_XML)
+                .header("Fiware-Service", "gateway").header("Fiware-ServicePath", "gateway1").header("X-Auth-Token", "XXXXXX"))
                 .andExpect(status().isOk());
     }
 
     @Test
     public void checkRegisterContextImplemented() throws Exception {
+        mockMvc.perform(post("/i/registerContext")
+                .content(json(jsonConverter, createRegisterContextTemperature()))
+                .contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON)
+                .header("Fiware-Service", "gateway").header("Fiware-ServicePath", "gateway1").header("X-Auth-Token", "XXXXXX"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void checkRegisterContextImplementedWithNullFiwareHeaders() throws Exception {
         mockMvc.perform(post("/i/registerContext")
                 .content(json(jsonConverter, createRegisterContextTemperature()))
                 .contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
@@ -168,7 +187,8 @@ public class NgsiBaseControllerTest {
     public void checkRegisterContextImplementedInXml() throws Exception {
         mockMvc.perform(post("/i/registerContext")
                 .content(xmlmapper.writeValueAsString(createRegisterContextTemperature()))
-                .contentType(MediaType.APPLICATION_XML).header("Host", "localhost").accept(MediaType.APPLICATION_XML))
+                .contentType(MediaType.APPLICATION_XML).header("Host", "localhost").accept(MediaType.APPLICATION_XML)
+                .header("Fiware-Service", "gateway").header("Fiware-ServicePath", "gateway1").header("X-Auth-Token", "XXXXXX"))
                 .andExpect(status().isOk());
     }
 
@@ -223,14 +243,26 @@ public class NgsiBaseControllerTest {
     @Test
     public void checkQueryContextImplemented() throws Exception {
         mockMvc.perform(
-                post("/i/queryContext").content(json(jsonConverter, createQueryContextTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                post("/i/queryContext").content(json(jsonConverter, createQueryContextTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON).header("Fiware-Service", "gateway")
+                        .header("Fiware-ServicePath", "gateway1").header("X-Auth-Token", "XXXXXX"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void checkQueryContextImplementedWithNullFiwareHeaders() throws Exception {
+        mockMvc.perform(
+                post("/i/queryContext").content(json(jsonConverter, createQueryContextTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     @Test
     public void checkQueryContextImplementedInXml() throws Exception {
         mockMvc.perform(
-                post("/i/queryContext").content(xmlmapper.writeValueAsString(createQueryContextTemperature())).contentType(MediaType.APPLICATION_XML).header("Host", "localhost").accept(MediaType.APPLICATION_XML))
+                post("/i/queryContext").content(xmlmapper.writeValueAsString(createQueryContextTemperature())).contentType(MediaType.APPLICATION_XML)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_XML).header("Fiware-Service", "gateway")
+                        .header("Fiware-ServicePath", "gateway1").header("X-Auth-Token", "XXXXXX"))
                 .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
When the cepheus broker receive the updateContext request or the queryContext request or the registerContext request it forward the requests to the remote broker with the Fiware headers.
The fiware headers are "Fiware-Service", "Fiware-ServicePath" and "X-Auth-Token".
