### PR TITLE
fiware-image-script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,8 @@
 # Setup Cepheus-CEP and Cepheus-Broker on Ubuntu 14.04 (trusty)
 
 # Cepheus version
+REPO="releases"
+VERSION="LATEST"
 
 # Check and echo all commands
 set -e


### PR DESCRIPTION
install.sh script doesn't depend on the release version, but it takes the latest version of releases