### PR TITLE
corrected coverity medium defects

### DIFF
--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/RemoteRegistrations.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/RemoteRegistrations.java
@@ -118,7 +118,7 @@ public class RemoteRegistrations {
      * @param localRegistrationId the local registrationId
      * @return the remote registrationId or null
      */
-    public String getRemoteRegistrationId(String localRegistrationId) {
+    public synchronized String getRemoteRegistrationId(String localRegistrationId) {
         RemoteRegistration remoteRegistration = registrations.get(localRegistrationId);
         return remoteRegistration != null ? remoteRegistration.registrationId : null;
     }

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
@@ -260,7 +260,7 @@ public class NgsiController extends NgsiBaseController {
             logger.warn("UpdateContext failed for {}: {}", brokerUrl, updateContextResponse.getErrorCode().toString());
         } else {
             updateContextResponse.getContextElementResponses().forEach(contextElementResponse -> {
-                if (contextElementResponse.getStatusCode().getCode().equals(CodeEnum.CODE_200)) {
+                if (contextElementResponse.getStatusCode().getCode().equals(CodeEnum.CODE_200.getLabel())) {
                     logger.debug("UpdateContext completed for {} ", brokerUrl);
                 } else {
                     logger.warn("UpdateContext failed for {}: entityId {} {}", brokerUrl,
@@ -271,7 +271,7 @@ public class NgsiController extends NgsiBaseController {
     }
 
     private void logNotifyContextResponse(NotifyContextResponse notifyContextResponse, String providerUrl) {
-        if (notifyContextResponse.getResponseCode().getCode().equals(CodeEnum.CODE_200)) {
+        if (notifyContextResponse.getResponseCode().getCode().equals(CodeEnum.CODE_200.getLabel())) {
             logger.debug("NotifyContext completed for {} ", providerUrl);
         } else {
             logger.warn("NotifyContext failed for {}: {}", providerUrl, notifyContextResponse.getResponseCode().toString());

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/EventSinkListener.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/EventSinkListener.java
@@ -76,6 +76,7 @@ public class EventSinkListener implements StatementAwareUpdateListener {
                 UpdateContext updateContext = buildUpdateContextRequest(eventBean, eventTypeOut);
                 if (updateContext != null) {
                     for (Broker broker : eventTypeOut.getBrokers()) {
+                        assert broker != null;
                         HttpHeaders httpHeaders = getHeadersForBroker(broker);
                         ngsiClient.updateContext(broker.getUrl(), httpHeaders, updateContext).addCallback(
                                 updateContextResponse ->

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/persistence/JsonPersistence.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/persistence/JsonPersistence.java
@@ -60,7 +60,11 @@ public class JsonPersistence implements Persistence {
         logger.info("Load configuration from {}", this.dataPath+filename);
 
         try {
-            return mapper.readValue(new File(this.dataPath+filename), Configuration.class);
+            Configuration configuration = mapper.readValue(new File(this.dataPath+filename), Configuration.class);
+            if (configuration == null) {
+                throw new PersistenceException("Failed to load configuration: empty configuration");
+            }
+            return configuration;
         } catch (IOException e) {
             throw new PersistenceException("Failed to load configuration", e);
         }

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/tenant/TenantFilter.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/tenant/TenantFilter.java
@@ -42,7 +42,7 @@ public class TenantFilter implements Filter {
 
     private static Logger logger = LoggerFactory.getLogger(TenantFilter.class);
 
-    private class BadHeaderException extends Exception {
+    private static class BadHeaderException extends Exception {
         public BadHeaderException(String message) {
             super(message);
         }
@@ -132,7 +132,7 @@ public class TenantFilter implements Filter {
 
         TenantScope.Context tenantMap = tenantContexts.get(tenantId);
         if (tenantMap == null) {
-            synchronized (tenantContexts) {
+            synchronized (this) {
                 tenantMap = tenantContexts.get(tenantId);
                 if (tenantMap == null) {
                     tenantMap = new TenantScope.Context();

--- a/cepheus-cep/src/main/java/com/orange/cepheus/geo/Geospatial.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/geo/Geospatial.java
@@ -46,8 +46,8 @@ public class Geospatial {
      * @param longitude
      * @return a point
      */
-    public static Point createPoint(double longitude, double latitude) {
-        return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+    public static Point createPoint(double latitude, double longitude) {
+        return geometryFactory.createPoint(new Coordinate(latitude, longitude));
     }
 
     /**

--- a/cepheus-cep/src/test/java/com/orange/cepheus/cep/persistence/PersistenceTest.java
+++ b/cepheus-cep/src/test/java/com/orange/cepheus/cep/persistence/PersistenceTest.java
@@ -83,6 +83,12 @@ public class PersistenceTest {
         persistence.loadConfiguration(configurationId);
     }
 
+    @Test(expected=PersistenceException.class)
+    public void loadNullConfigurationThrowException() throws PersistenceException {
+        persistence.saveConfiguration(configurationId, null);
+        persistence.loadConfiguration(configurationId);
+    }
+
     private void clearPersistedConfiguration() {
         File confFile = new File(path);
         if (confFile.exists()) {


### PR DESCRIPTION
CID 156750: null check in EventSinkListenner class
CID 156752: no lock on registrationId access in RemoteRegistration class
CID 156753: no checks on null configuration in JsonPersistence class
CID 156754: bad arguments ordering/naming in Geospatial class
CID 156756: bad enum compare (on logs only) in NgsiController class
CID 156757: tenantContexts concurrent warn in TenantFilter class
CID 156758: BadHeaderException class can be static