### PR TITLE
REST NGSI10 support

### DIFF
--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiController.java
@@ -33,7 +33,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 /**
- * NGSI Controller : NGSI operation implemented by Cepheus-lightbroker
+ * NGSI standard operations
+ *  - all NGSI-10 operations except /updateContextSubscription
+ *  - none of NGSI-9 operations but /registerContext (used by IoTAgents)
  */
 @RestController
 @RequestMapping(value = {"/v1", "/v1/registry", "/ngsi9", "/NGSI9", "/ngsi10", "/NGSI10"})
@@ -178,6 +180,15 @@ public class NgsiController extends NgsiBaseController {
         subscribeContextResponse.setSubscribeResponse(subscribeResponse);
 
         return subscribeContextResponse;
+    }
+
+    /**
+     * Unsupported, will throw an UnsupportedOperationException
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public UpdateContextSubscriptionResponse updateContextSubscription(final UpdateContextSubscription updateContextSubscription) throws Exception {
+        return super.updateContextSubscription(updateContextSubscription);
     }
 
     @Override

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiRestController.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiRestController.java
@@ -1,7 +1,272 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.broker.controller;
 
+import com.orange.ngsi.exception.UnsupportedOperationException;
+import com.orange.ngsi.model.*;
+import com.orange.ngsi.server.NgsiRestBaseController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.*;
+
 /**
- * Created by marc on 01/02/2016.
+ * NGSI REST convenient operations
+ *  - only NGSI-10, no NGSI-9
+ *  - forwarding all convenient requests to standard operations (updateContext, queryContext, ...)
  */
-public class NgsiRestController {
+@RestController
+@RequestMapping(value = {"/v1", "/ngsi10", "/NGSI10"})
+public class NgsiRestController extends NgsiRestBaseController {
+
+    @Autowired
+    private NgsiController ngsiController;
+
+    @Override
+    protected AppendContextElementResponse appendContextElement(String entityID, AppendContextElement appendContextElement) throws Exception {
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId(entityID, "", false));
+        contextElement.setContextAttributeList(appendContextElement.getAttributeList());
+
+        UpdateContext updateContext = new UpdateContext();
+        updateContext.setContextElements(Collections.singletonList(contextElement));
+        updateContext.setUpdateAction(UpdateAction.APPEND);
+
+        UpdateContextResponse updateContextResponse = ngsiController.updateContext(updateContext);
+
+
+        // Transform an UpdateContextResponse to a AppendContextElementResponse...
+        AppendContextElementResponse appendContextElementResponse = new AppendContextElementResponse();
+        if (updateContextResponse.getErrorCode() != null) {
+            appendContextElementResponse.setErrorCode(updateContextResponse.getErrorCode());
+        } else {
+            // There should be only one ContextElementResponse
+            List <ContextAttributeResponse> attributeResponses = new LinkedList<>();
+            updateContextResponse.getContextElementResponses().forEach(response -> {
+                appendContextElementResponse.setEntityId(response.getContextElement().getEntityId());
+                response.getContextElement().getContextAttributeList().forEach(contextAttribute -> {
+                            ContextAttributeResponse attributeResponse = new ContextAttributeResponse();
+                            attributeResponse.setContextAttributeList(response.getContextElement().getContextAttributeList());
+                            attributeResponse.setStatusCode(response.getStatusCode());
+                            attributeResponses.add(attributeResponse);
+                        });
+                    });
+            appendContextElementResponse.setContextAttributeResponses(attributeResponses);
+        }
+        return appendContextElementResponse;
+    }
+
+    @Override
+    protected UpdateContextElementResponse updateContextElement(String entityID, UpdateContextElement updateContextElement) throws Exception {
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId(entityID, "", false));
+        contextElement.setContextAttributeList(updateContextElement.getContextAttributes());
+
+        UpdateContext updateContext = new UpdateContext();
+        updateContext.setContextElements(Collections.singletonList(contextElement));
+        updateContext.setUpdateAction(UpdateAction.UPDATE);
+
+        UpdateContextResponse updateContextResponse = ngsiController.updateContext(updateContext);
+
+        // Transform an UpdateContextResponse to a AppendContextElementResponse...
+        UpdateContextElementResponse updateContextElementResponse = new UpdateContextElementResponse();
+        if (updateContextResponse.getErrorCode() != null) {
+            updateContextElementResponse.setErrorCode(updateContextResponse.getErrorCode());
+        } else {
+            // There should be a single ContextElementResponse
+            List <ContextAttributeResponse> attributeResponses = new LinkedList<>();
+            updateContextResponse.getContextElementResponses().forEach(response -> {
+                response.getContextElement().getContextAttributeList().forEach(contextAttribute -> {
+                    ContextAttributeResponse attributeResponse = new ContextAttributeResponse();
+                    attributeResponse.setContextAttributeList(response.getContextElement().getContextAttributeList());
+                    attributeResponse.setStatusCode(response.getStatusCode());
+                    attributeResponses.add(attributeResponse);
+                });
+            });
+            updateContextElementResponse.setContextAttributeResponses(attributeResponses);
+        }
+        return updateContextElementResponse;
+    }
+
+    @Override
+    protected ContextElementResponse getContextElement(String entityID) throws Exception {
+
+        QueryContext queryContext = new QueryContext((Collections.singletonList(new EntityId(entityID, "", false))));
+
+        QueryContextResponse response = ngsiController.queryContext(queryContext);
+
+        // Transform a QueryContextResponse to a ContextElementResponse
+        ContextElementResponse contextElementResponse = new ContextElementResponse();
+        if (response.getErrorCode() != null) {
+            contextElementResponse.setStatusCode(response.getErrorCode());
+        } else {
+            // There should be a single ContextElementResponse
+            contextElementResponse.setContextElement(response.getContextElementResponses().get(0).getContextElement());
+            contextElementResponse.setStatusCode(response.getContextElementResponses().get(0).getStatusCode());
+        }
+        return contextElementResponse;
+    }
+
+    @Override
+    protected StatusCode deleteContextElement(String entityID) throws Exception {
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId(entityID, "", false));
+
+        UpdateContext updateContext = new UpdateContext();
+        updateContext.setContextElements(Collections.singletonList(contextElement));
+        updateContext.setUpdateAction(UpdateAction.DELETE);
+
+        UpdateContextResponse response = ngsiController.updateContext(updateContext);
+
+        // Transform an UpdateContextResponse to a StatusCode
+        if (response.getErrorCode() != null) {
+            return response.getErrorCode();
+        }
+        // There should be a single ContextElementResponse
+        return response.getContextElementResponses().get(0).getStatusCode();
+    }
+
+    @Override
+    protected StatusCode appendContextAttribute(String entityID, String attributeName, UpdateContextAttribute updateContextAttribute) throws Exception {
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId(entityID, "", false));
+        contextElement.setContextAttributeList(Collections.singletonList(updateContextAttribute.getAttribute()));
+
+        UpdateContext updateContext = new UpdateContext();
+        updateContext.setContextElements(Collections.singletonList(contextElement));
+        updateContext.setUpdateAction(UpdateAction.APPEND);
+
+        UpdateContextResponse updateContextResponse = ngsiController.updateContext(updateContext);
+
+        // Transform an UpdateContextResponse to a AppendContextElementResponse...
+        AppendContextElementResponse appendContextElementResponse = new AppendContextElementResponse();
+        if (updateContextResponse.getErrorCode() != null) {
+            return updateContextResponse.getErrorCode();
+        }
+        // There should be only one ContextElementResponse
+        return updateContextResponse.getContextElementResponses().get(0).getStatusCode();
+    }
+
+    @Override
+    protected StatusCode updateContextAttribute(String entityID, String attributeName,
+            UpdateContextAttribute updateContextAttribute) throws Exception {
+        return this.updateContextAttributeValue(entityID, attributeName, null, updateContextAttribute);
+    }
+
+    @Override
+    protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName) throws Exception {
+
+        QueryContext queryContext = new QueryContext((Collections.singletonList(new EntityId(entityID, "", false))));
+        queryContext.setAttributeList(Collections.singletonList(attributeName));
+
+        QueryContextResponse response = ngsiController.queryContext(queryContext);
+
+        // Transform a QueryContextResponse to a ContextAttributeResponse
+        ContextAttributeResponse contextAttributeResponse = new ContextAttributeResponse();
+        if (response.getErrorCode() != null) {
+            contextAttributeResponse.setStatusCode(response.getErrorCode());
+        } else {
+            // There should be a single ContextElementResponse
+            contextAttributeResponse.setStatusCode(response.getContextElementResponses().get(0).getStatusCode());
+            contextAttributeResponse.setContextAttributeList(response.getContextElementResponses().get(0).getContextElement().getContextAttributeList());
+        }
+        return contextAttributeResponse;
+    }
+
+    @Override
+    protected StatusCode updateContextAttributeValue(String entityID, String attributeName, String valueID,
+            UpdateContextAttribute updateContextAttribute) throws Exception {
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId(entityID, "", false));
+        contextElement.setContextAttributeList(Collections.singletonList(updateContextAttribute.getAttribute()));
+
+        UpdateContext updateContext = new UpdateContext();
+        updateContext.setContextElements(Collections.singletonList(contextElement));
+        updateContext.setUpdateAction(UpdateAction.UPDATE);
+
+        UpdateContextResponse updateContextResponse = ngsiController.updateContext(updateContext);
+
+        // Transform an UpdateContextResponse to a AppendContextElementResponse...
+        AppendContextElementResponse appendContextElementResponse = new AppendContextElementResponse();
+        if (updateContextResponse.getErrorCode() != null) {
+            return updateContextResponse.getErrorCode();
+        }
+        // There should be only one ContextElementResponse
+        return updateContextResponse.getContextElementResponses().get(0).getStatusCode();
+    }
+
+    @Override
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName) throws Exception {
+        return this.deleteContextAttributeValue(entityID, attributeName, null);
+    }
+
+    @Override
+    protected ContextAttributeResponse getContextAttributeValue(String entityID, String attributeName, String valueID) throws Exception {
+        // QueryContext cannot handle filtering by metadata ID
+        throw new UnsupportedOperationException("cannot handle valueID");
+    }
+
+    @Override
+    protected StatusCode deleteContextAttributeValue(String entityID, String attributeName, String valueID) throws Exception {
+
+        ContextAttribute contextAttribute = new ContextAttribute(attributeName, "", "");
+        if (valueID != null) {
+            contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", valueID)));
+        }
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId(entityID, "", false));
+        contextElement.setContextAttributeList(Collections.singletonList(contextAttribute));
+
+        UpdateContext updateContext = new UpdateContext();
+        updateContext.setContextElements(Collections.singletonList(contextElement));
+        updateContext.setUpdateAction(UpdateAction.DELETE);
+
+        UpdateContextResponse updateContextResponse = ngsiController.updateContext(updateContext);
+
+        if (updateContextResponse.getErrorCode() != null) {
+            return updateContextResponse.getErrorCode();
+        }
+        // There should be only a single ContextElementResponse
+        return updateContextResponse.getContextElementResponses().get(0).getStatusCode();
+    }
+
+    @Override
+    protected QueryContextResponse getContextEntitiesType(String typeName) throws Exception {
+        return this.getContextEntitiesType(typeName, null);
+    }
+
+    @Override
+    protected QueryContextResponse getContextEntitiesType(String typeName, String attributeName) throws Exception {
+        QueryContext queryContext = new QueryContext((Collections.singletonList(new EntityId(".*", typeName, true))));
+        if (attributeName != null) {
+            queryContext.setAttributeList(Collections.singletonList(attributeName));
+        }
+        return ngsiController.queryContext(queryContext);
+    }
+
+    @Override
+    protected SubscribeContextResponse createSubscription(SubscribeContext subscribeContext) throws Exception {
+        return ngsiController.subscribeContext(subscribeContext);
+    }
+
+    @Override
+    protected UpdateContextSubscriptionResponse updateSubscription(UpdateContextSubscription updateContextSubscription) throws Exception {
+        return ngsiController.updateContextSubscription(updateContextSubscription);
+    }
+
+    @Override
+    protected UnsubscribeContextResponse deleteSubscription(String subscriptionID) throws Exception {
+        return ngsiController.unsubscribeContext(new UnsubscribeContext(subscriptionID));
+    }
 }

--- a/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiRestController.java
+++ b/cepheus-broker/src/main/java/com/orange/cepheus/broker/controller/NgsiRestController.java
@@ -1,0 +1,7 @@
+package com.orange.cepheus.broker.controller;
+
+/**
+ * Created by marc on 01/02/2016.
+ */
+public class NgsiRestController {
+}

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/Util.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/Util.java
@@ -165,6 +165,13 @@ public class Util {
         return subscribeContextResponse;
     }
 
+    static public UpdateContextSubscription createUpdateSubscribeContext() {
+        UpdateContextSubscription updateContextSubscription = new UpdateContextSubscription();
+        updateContextSubscription.setDuration("P3M");
+        updateContextSubscription.setSubscriptionId("12345678");
+        return updateContextSubscription;
+    }
+
     static public RegisterContext createRegisterContextTemperature() throws URISyntaxException {
         RegisterContext registerContext = new RegisterContext();
 

--- a/cepheus-broker/src/test/java/com/orange/cepheus/broker/controller/NgsiRestControllerTest.java
+++ b/cepheus-broker/src/test/java/com/orange/cepheus/broker/controller/NgsiRestControllerTest.java
@@ -1,0 +1,741 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.cepheus.broker.controller;
+
+import com.orange.cepheus.broker.Application;
+import com.orange.ngsi.model.*;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.annotation.PostConstruct;
+import java.util.Collections;
+import java.util.List;
+
+import static com.orange.cepheus.broker.Util.createSubscribeContextTemperature;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static com.orange.cepheus.broker.Util.*;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the NgsiRestController
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@WebAppConfiguration
+public class NgsiRestControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter mapper;
+
+    @Mock
+    private NgsiController ngsiController;
+
+    @Autowired
+    @InjectMocks
+    private NgsiRestController ngsiRestController;
+
+    @PostConstruct
+    public void tearUp() {
+        MockitoAnnotations.initMocks(this);
+        mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @After
+    public void teadDown() {
+        reset(ngsiController);
+    }
+
+    @Test
+    public void testAppendContextElement_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        AppendContextElement appendContextElement = new AppendContextElement();
+        appendContextElement.setAttributeList(attributes);
+
+        mockMvc.perform(post("/v1/contextEntities/12345678").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+                .content(json(mapper, appendContextElement))).andExpect(status().isOk()).andExpect(jsonPath("$.errorCode").doesNotExist())
+                .andExpect(jsonPath("$.id").value("12345678")).andExpect(jsonPath("$.type").value(""))
+                .andExpect(jsonPath("$.isPattern").value("false"))
+                .andExpect(jsonPath("$.contextResponses[0].attributes[0].name").value("test"))
+                .andExpect(jsonPath("$.contextResponses[0].attributes[0].type").value("string"))
+                .andExpect(jsonPath("$.contextResponses[0].attributes[0].value").value("OK"))
+                .andExpect(jsonPath("$.contextResponses[0].statusCode.code").value("200"));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContextRequest = updateContextArg.getValue();
+        assertNotNull(updateContextRequest);
+        assertEquals(UpdateAction.APPEND, updateContextRequest.getUpdateAction());
+        assertEquals("12345678", updateContextRequest.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContextRequest.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContextRequest.getContextElements().get(0).getEntityId().getIsPattern());
+    }
+
+    @Test
+    public void testAppendContextElement_Error() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_400));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        AppendContextElement appendContextElement = new AppendContextElement();
+        appendContextElement.setAttributeList(attributes);
+
+        mockMvc.perform(post("/v1/contextEntities/12345678").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+                .content(json(mapper, appendContextElement))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.errorCode.code").value("400")).andExpect(jsonPath("$.id").doesNotExist())
+                .andExpect(jsonPath("$.type").doesNotExist()).andExpect(jsonPath("$.isPattern").doesNotExist())
+                .andExpect(jsonPath("$.contextResponses").doesNotExist());
+
+        verify(ngsiController).updateContext(any());
+    }
+
+    @Test
+    public void testUpdateContextElement_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextElement updateContextElement = new UpdateContextElement();
+        updateContextElement.setContextAttributes(attributes);
+
+        mockMvc.perform(put("/v1/contextEntities/12345678").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+                .content(json(mapper, updateContextElement))).andExpect(status().isOk()).andExpect(jsonPath("$.errorCode").doesNotExist())
+                .andExpect(jsonPath("$.contextResponses[0].attributes[0].name").value("test"))
+                .andExpect(jsonPath("$.contextResponses[0].attributes[0].type").value("string"))
+                .andExpect(jsonPath("$.contextResponses[0].attributes[0].value").value("OK"))
+                .andExpect(jsonPath("$.contextResponses[0].statusCode.code").value("200"));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContextRequest = updateContextArg.getValue();
+        assertNotNull(updateContextRequest);
+        assertEquals(UpdateAction.UPDATE, updateContextRequest.getUpdateAction());
+        assertEquals("12345678", updateContextRequest.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContextRequest.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContextRequest.getContextElements().get(0).getEntityId().getIsPattern());
+    }
+
+    @Test
+    public void testUpdateContextElement_Error() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_400));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextElement updateContextElement = new UpdateContextElement();
+        updateContextElement.setContextAttributes(attributes);
+
+        mockMvc.perform(put("/v1/contextEntities/12345678").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+                .content(json(mapper, updateContextElement))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.errorCode.code").value("400")).andExpect(jsonPath("$.contextResponses").doesNotExist());
+
+        verify(ngsiController).updateContext(any());
+    }
+
+    @Test
+    public void testGetContextElement_OK() throws Exception {
+        ArgumentCaptor<QueryContext> queryContextArg = ArgumentCaptor.forClass(QueryContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        QueryContextResponse response = new QueryContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntities/12345678").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode.code").value("200"))
+                .andExpect(jsonPath("$.contextElement.attributes[0].name").value("test"))
+                .andExpect(jsonPath("$.contextElement.attributes[0].type").value("string"))
+                .andExpect(jsonPath("$.contextElement.attributes[0].value").value("OK"));
+
+        verify(ngsiController).queryContext(queryContextArg.capture());
+
+        QueryContext queryContext = queryContextArg.getValue();
+        assertNotNull(queryContext);
+        assertNotNull(queryContext.getEntityIdList());
+        assertEquals(1, queryContext.getEntityIdList().size());
+        assertNull(queryContext.getAttributeList());
+        assertEquals("12345678", queryContext.getEntityIdList().get(0).getId());
+        assertEquals("", queryContext.getEntityIdList().get(0).getType());
+        assertEquals(false, queryContext.getEntityIdList().get(0).getIsPattern());
+    }
+
+    @Test
+    public void testGetContextElement_Error() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        QueryContextResponse response = new QueryContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_400));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntities/12345678").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode.code").value("400")).andExpect(jsonPath("$.contextElement").doesNotExist());
+
+        verify(ngsiController).queryContext(any());
+    }
+
+    @Test
+    public void testDeleteContextElement_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        mockMvc.perform(delete("/v1/contextEntities/12345678").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContext = updateContextArg.getValue();
+        assertNotNull(updateContext);
+        assertNotNull(updateContext.getContextElements());
+        assertEquals(1, updateContext.getContextElements().size());
+        assertEquals(UpdateAction.DELETE, updateContext.getUpdateAction());
+        assertEquals("12345678", updateContext.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContext.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContext.getContextElements().get(0).getEntityId().getIsPattern());
+    }
+
+    @Test
+    public void testDeleteContextElement_Error() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_400));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        mockMvc.perform(delete("/v1/contextEntities/12345678").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("400"));
+
+        verify(ngsiController).updateContext(any());
+    }
+
+    @Test
+    public void testAppendContextAttribute_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        ContextAttribute attribute = new ContextAttribute("temp", "float", "15.5");
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(Collections.singletonList(attribute));
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(attribute);
+
+        mockMvc.perform(post("/v1/contextEntities/12345678/attributes/temp").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContextRequest = updateContextArg.getValue();
+        assertNotNull(updateContextRequest);
+        assertEquals(UpdateAction.APPEND, updateContextRequest.getUpdateAction());
+        assertNotNull(updateContextRequest.getContextElements());
+        assertEquals(1, updateContextRequest.getContextElements().size());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getEntityId());
+        assertEquals("12345678", updateContextRequest.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContextRequest.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContextRequest.getContextElements().get(0).getEntityId().getIsPattern());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getContextAttributeList());
+        assertEquals(1, updateContextRequest.getContextElements().get(0).getContextAttributeList().size());
+        assertEquals("temp", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("float", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("15.5", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getValue());
+    }
+
+    @Test
+    public void testAppendContextAttribute_EmptyAttrError() throws Exception {
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(null);
+
+        mockMvc.perform(post("/v1/contextEntities/12345678/attributes/temp")
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute)))
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_472.getLabel()));
+
+        verify(ngsiController, never()).updateContext(any());
+    }
+
+    @Test
+    public void testAppendContextAttribute_MismatchAttrError() throws Exception {
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(new ContextAttribute("temp", "float", "15.5"));
+
+        mockMvc.perform(post("/v1/contextEntities/12345678/attributes/BAD_ATTR").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute)))
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_472.getLabel()));
+
+        verify(ngsiController, never()).updateContext(any());
+    }
+
+    @Test
+    public void testAppendContextAttribute_Error() throws Exception {
+
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_500));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(new ContextAttribute("temp", "float", "15.5"));
+
+        mockMvc.perform(post("/v1/contextEntities/12345678/attributes/temp").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_500.getLabel()));
+
+        verify(ngsiController).updateContext(any());
+    }
+
+    @Test
+    public void testUpdateContextAttribute_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        ContextAttribute attribute = new ContextAttribute("temp", "float", "15.5");
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(Collections.singletonList(attribute));
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(attribute);
+
+        mockMvc.perform(put("/v1/contextEntities/12345678/attributes/temp").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContextRequest = updateContextArg.getValue();
+        assertNotNull(updateContextRequest);
+        assertEquals(UpdateAction.UPDATE, updateContextRequest.getUpdateAction());
+        assertNotNull(updateContextRequest.getContextElements());
+        assertEquals(1, updateContextRequest.getContextElements().size());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getEntityId());
+        assertEquals("12345678", updateContextRequest.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContextRequest.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContextRequest.getContextElements().get(0).getEntityId().getIsPattern());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getContextAttributeList());
+        assertEquals(1, updateContextRequest.getContextElements().get(0).getContextAttributeList().size());
+        assertEquals("temp", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("float", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("15.5", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getValue());
+    }
+
+    @Test
+    public void testUpdateContextAttribute_EmptyAttrError() throws Exception {
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(null);
+
+        mockMvc.perform(put("/v1/contextEntities/12345678/attributes/temp").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute)))
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_472.getLabel()));
+
+        verify(ngsiController, never()).updateContext(any());
+    }
+
+    @Test
+    public void testUpdateContextAttribute_MismatchAttrError() throws Exception {
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(new ContextAttribute("temp", "float", "15.5"));
+
+        mockMvc.perform(put("/v1/contextEntities/12345678/attributes/BAD_ATTR").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute)))
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_472.getLabel()));
+
+        verify(ngsiController, never()).updateContext(any());
+    }
+
+    @Test
+    public void testUpdateContextAttribute_Error() throws Exception {
+
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_500));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(new ContextAttribute("temp", "float", "15.5"));
+
+        mockMvc.perform(put("/v1/contextEntities/12345678/attributes/temp").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_500.getLabel()));
+
+        verify(ngsiController).updateContext(any());
+    }
+
+    @Test
+    public void testGetContextAttribute_OK() throws Exception {
+        ArgumentCaptor<QueryContext> queryContextArg = ArgumentCaptor.forClass(QueryContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        QueryContextResponse response = new QueryContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntities/12345678/attributes/test").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode.code").value("200"))
+                .andExpect(jsonPath("$.attributes[0].name").value("test"))
+                .andExpect(jsonPath("$.attributes[0].type").value("string"))
+                .andExpect(jsonPath("$.attributes[0].value").value("OK"));
+
+        verify(ngsiController).queryContext(queryContextArg.capture());
+
+        QueryContext queryContext = queryContextArg.getValue();
+        assertNotNull(queryContext);
+        assertNotNull(queryContext.getEntityIdList());
+        assertEquals(1, queryContext.getEntityIdList().size());
+        assertEquals("12345678", queryContext.getEntityIdList().get(0).getId());
+        assertEquals("", queryContext.getEntityIdList().get(0).getType());
+        assertEquals(false, queryContext.getEntityIdList().get(0).getIsPattern());
+        assertNotNull(queryContext.getAttributeList());
+        assertEquals(1, queryContext.getAttributeList().size());
+        assertEquals("test", queryContext.getAttributeList().get(0));
+    }
+
+    @Test
+    public void testDeleteContextAttribute_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        mockMvc.perform(delete("/v1/contextEntities/12345678/attributes/test").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContext = updateContextArg.getValue();
+        assertNotNull(updateContext);
+        assertNotNull(updateContext.getContextElements());
+        assertEquals(1, updateContext.getContextElements().size());
+        assertEquals(UpdateAction.DELETE, updateContext.getUpdateAction());
+        assertEquals("12345678", updateContext.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContext.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContext.getContextElements().get(0).getEntityId().getIsPattern());
+        assertNotNull(updateContext.getContextElements().get(0).getContextAttributeList());
+        assertEquals(1, updateContext.getContextElements().get(0).getContextAttributeList().size());
+        assertEquals("test", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getValue());
+    }
+
+    @Test
+    public void testUpdateContextAttributeValue_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        ContextAttribute attribute = new ContextAttribute("temp", "float", "15.5");
+        attribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "DEADBEEF")));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(Collections.singletonList(attribute));
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(attribute);
+
+        mockMvc.perform(put("/v1/contextEntities/12345678/attributes/temp/DEADBEEF").contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON).content(json(mapper, updateContextAttribute))).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContextRequest = updateContextArg.getValue();
+        assertNotNull(updateContextRequest);
+        assertEquals(UpdateAction.UPDATE, updateContextRequest.getUpdateAction());
+        assertNotNull(updateContextRequest.getContextElements());
+        assertEquals(1, updateContextRequest.getContextElements().size());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getEntityId());
+        assertEquals("12345678", updateContextRequest.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContextRequest.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContextRequest.getContextElements().get(0).getEntityId().getIsPattern());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getContextAttributeList());
+        assertEquals(1, updateContextRequest.getContextElements().get(0).getContextAttributeList().size());
+        assertEquals("temp", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("float", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("15.5", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getValue());
+        assertNotNull(updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getMetadata());
+        assertEquals(1, updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().size());
+        assertEquals("ID", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().get(0).getName());
+        assertEquals("string", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().get(0).getType());
+        assertEquals("DEADBEEF", updateContextRequest.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().get(0).getValue());
+    }
+
+    @Test
+    public void testGetContextAttributeValue_NotImplemented() throws Exception {
+        ArgumentCaptor<QueryContext> queryContextArg = ArgumentCaptor.forClass(QueryContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        QueryContextResponse response = new QueryContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntities/12345678/attributes/test/DEADBEEF").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("500"));
+
+        verify(ngsiController, never()).queryContext(queryContextArg.capture());
+    }
+
+    @Test
+    public void testDeleteContextAttributeValue_OK() throws Exception {
+        ArgumentCaptor<UpdateContext> updateContextArg = ArgumentCaptor.forClass(UpdateContext.class);
+
+        ContextAttribute contextAttribute = new ContextAttribute("test", "string", "OK");
+        contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "DEADBEEF")));
+        List attributes = Collections.singletonList(contextAttribute);
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        UpdateContextResponse response = new UpdateContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.updateContext(any())).thenReturn(response);
+
+        mockMvc.perform(delete("/v1/contextEntities/12345678/attributes/test/DEADBEEF").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"));
+
+        verify(ngsiController).updateContext(updateContextArg.capture());
+
+        UpdateContext updateContext = updateContextArg.getValue();
+        assertNotNull(updateContext);
+        assertNotNull(updateContext.getContextElements());
+        assertEquals(1, updateContext.getContextElements().size());
+        assertEquals(UpdateAction.DELETE, updateContext.getUpdateAction());
+        assertEquals("12345678", updateContext.getContextElements().get(0).getEntityId().getId());
+        assertEquals("", updateContext.getContextElements().get(0).getEntityId().getType());
+        assertEquals(false, updateContext.getContextElements().get(0).getEntityId().getIsPattern());
+        assertNotNull(updateContext.getContextElements().get(0).getContextAttributeList());
+        assertEquals(1, updateContext.getContextElements().get(0).getContextAttributeList().size());
+        assertEquals("test", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getValue());
+        assertNotNull(updateContext.getContextElements().get(0).getContextAttributeList().get(0).getMetadata());
+        assertEquals(1, updateContext.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().size());
+        assertEquals("ID", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().get(0).getName());
+        assertEquals("string", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().get(0).getType());
+        assertEquals("DEADBEEF", updateContext.getContextElements().get(0).getContextAttributeList().get(0).getMetadata().get(0).getValue());
+    }
+
+    @Test
+    public void testGetContextEntityTypes_OK() throws Exception {
+        ArgumentCaptor<QueryContext> queryContextArg = ArgumentCaptor.forClass(QueryContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "TempSensor", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        QueryContextResponse response = new QueryContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntityTypes/TempSensor").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andDo(mvcResult -> System.out.println(mvcResult.getResponse().getContentAsString()))
+                .andExpect(jsonPath("$.errorCode").doesNotExist())
+                .andExpect(jsonPath("$.contextResponses").isArray())
+                .andExpect(jsonPath("$.contextResponses[0].statusCode.code").value("200"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.id").value("12345678"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.type").value("TempSensor"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.isPattern").value("false"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.attributes[0].name").value("test"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.attributes[0].type").value("string"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.attributes[0].value").value("OK"));
+
+        verify(ngsiController).queryContext(queryContextArg.capture());
+
+        QueryContext queryContext = queryContextArg.getValue();
+        assertNotNull(queryContext);
+        assertNotNull(queryContext.getEntityIdList());
+        assertEquals(1, queryContext.getEntityIdList().size());
+        assertNull(queryContext.getAttributeList());
+        assertEquals(".*", queryContext.getEntityIdList().get(0).getId());
+        assertEquals("TempSensor", queryContext.getEntityIdList().get(0).getType());
+        assertEquals(true, queryContext.getEntityIdList().get(0).getIsPattern());
+    }
+
+    @Test
+    public void testGetContextEntityTypes_Error() throws Exception {
+        QueryContextResponse response = new QueryContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_500));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntityTypes/TempSensor").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andDo(mvcResult -> System.out.println(mvcResult.getResponse().getContentAsString()))
+                .andExpect(jsonPath("$.errorCode.code").value("500"))
+                .andExpect(jsonPath("$.contextResponses").doesNotExist());
+
+        verify(ngsiController).queryContext(any());
+    }
+
+    @Test
+    public void testGetContextEntityTypesAttribute_OK() throws Exception {
+        ArgumentCaptor<QueryContext> queryContextArg = ArgumentCaptor.forClass(QueryContext.class);
+
+        List attributes = Collections.singletonList(new ContextAttribute("test", "string", "OK"));
+
+        ContextElement contextElement = new ContextElement();
+        contextElement.setEntityId(new EntityId("12345678", "TempSensor", false));
+        contextElement.setContextAttributeList(attributes);
+        ContextElementResponse contextElementResponse = new ContextElementResponse(contextElement, new StatusCode(CodeEnum.CODE_200));
+        QueryContextResponse response = new QueryContextResponse();
+        response.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntityTypes/TempSensor/attributes/temp").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andDo(mvcResult -> System.out.println(mvcResult.getResponse().getContentAsString()))
+                .andExpect(jsonPath("$.errorCode").doesNotExist())
+                .andExpect(jsonPath("$.contextResponses").isArray())
+                .andExpect(jsonPath("$.contextResponses[0].statusCode.code").value("200"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.id").value("12345678"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.type").value("TempSensor"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.isPattern").value("false"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.attributes[0].name").value("test"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.attributes[0].type").value("string"))
+                .andExpect(jsonPath("$.contextResponses[0].contextElement.attributes[0].value").value("OK"));
+
+        verify(ngsiController).queryContext(queryContextArg.capture());
+
+        QueryContext queryContext = queryContextArg.getValue();
+        assertNotNull(queryContext);
+        assertNotNull(queryContext.getEntityIdList());
+        assertEquals(1, queryContext.getEntityIdList().size());
+        assertNotNull(queryContext.getAttributeList());
+        assertEquals(".*", queryContext.getEntityIdList().get(0).getId());
+        assertEquals("TempSensor", queryContext.getEntityIdList().get(0).getType());
+        assertEquals(true, queryContext.getEntityIdList().get(0).getIsPattern());
+        assertEquals("temp", queryContext.getAttributeList().get(0));
+    }
+
+    @Test
+    public void testGetContextEntityTypesAttribute_Error() throws Exception {
+        QueryContextResponse response = new QueryContextResponse();
+        response.setErrorCode(new StatusCode(CodeEnum.CODE_500));
+        when(ngsiController.queryContext(any())).thenReturn(response);
+
+        mockMvc.perform(get("/v1/contextEntityTypes/TempSensor/attributes/temp").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andDo(mvcResult -> System.out.println(mvcResult.getResponse().getContentAsString()))
+                .andExpect(jsonPath("$.errorCode.code").value("500"))
+                .andExpect(jsonPath("$.contextResponses").doesNotExist());
+
+        verify(ngsiController).queryContext(any());
+    }
+
+    @Test
+    public void testAppendSubscription() throws Exception {
+
+        mockMvc.perform(post("/v1/contextSubscriptions")
+                .content(json(mapper, createSubscribeContextTemperature()))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(ngsiController).subscribeContext(any());
+    }
+
+    @Test
+    public void testUpdateSubscription() throws Exception {
+
+        mockMvc.perform(put("/v1/contextSubscriptions/12345678")
+                .content(json(mapper, createUpdateSubscribeContext()))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(ngsiController).updateContextSubscription(any());
+    }
+
+    @Test
+    public void testDeleteSubscription() throws Exception {
+
+        mockMvc.perform(delete("/v1/contextSubscriptions/12345678"))
+                .andExpect(status().isOk());
+
+        verify(ngsiController).unsubscribeContext(any());
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/ConvertersConfiguration.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/ConvertersConfiguration.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.orange.ngsi.model.AppendContextElementResponse;
 import com.orange.ngsi.model.ContextElement;
 import com.orange.ngsi.model.EntityIdMixIn;
 import org.springframework.context.annotation.Bean;
@@ -47,6 +48,7 @@ public class ConvertersConfiguration {
         objectMapper.registerModule(booleanAsString);
 
         objectMapper.addMixIn(ContextElement.class, EntityIdMixIn.class);
+        objectMapper.addMixIn(AppendContextElementResponse.class, EntityIdMixIn.class);
 
         return new MappingJackson2HttpMessageConverter(objectMapper);
     }

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/ConvertersConfiguration.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/ConvertersConfiguration.java
@@ -15,13 +15,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.orange.ngsi.model.ContextElement;
-import com.orange.ngsi.model.ContextElementMixIn;
+import com.orange.ngsi.model.EntityIdMixIn;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
-import javax.annotation.Resource;
 import java.io.IOException;
 
 
@@ -48,7 +46,7 @@ public class ConvertersConfiguration {
         });
         objectMapper.registerModule(booleanAsString);
 
-        objectMapper.addMixIn(ContextElement.class, ContextElementMixIn.class);
+        objectMapper.addMixIn(ContextElement.class, EntityIdMixIn.class);
 
         return new MappingJackson2HttpMessageConverter(objectMapper);
     }

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/client/NgsiClient.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/client/NgsiClient.java
@@ -154,13 +154,23 @@ public class NgsiClient {
         return requestHeaders;
     }
 
-    private <T,U> ListenableFuture<T> request(String url, HttpHeaders httpHeaders, U body, Class<T> responseType) {
+    /**
+     * Default POST request
+     */
+    protected <T,U> ListenableFuture<T> request(String url, HttpHeaders httpHeaders, U body, Class<T> responseType) {
+        return request(HttpMethod.POST, url, httpHeaders, body, responseType);
+    }
+
+    /**
+     * Make an HTTP request
+     */
+    protected <T,U> ListenableFuture<T> request(HttpMethod method, String url, HttpHeaders httpHeaders, U body, Class<T> responseType) {
         if (httpHeaders == null) {
             httpHeaders = getRequestHeaders(url);
         }
         HttpEntity<U> requestEntity = new HttpEntity<>(body, httpHeaders);
 
-        ListenableFuture<ResponseEntity<T>> future = asyncRestTemplate.exchange(url, HttpMethod.POST, requestEntity, responseType);
+        ListenableFuture<ResponseEntity<T>> future = asyncRestTemplate.exchange(url, method, requestEntity, responseType);
 
         return new ListenableFutureAdapter<T, ResponseEntity<T>>(future) {
             @Override

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/client/NgsiRestClient.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/client/NgsiRestClient.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.client;
+
+import com.orange.ngsi.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ * NGSI REST convenient operations
+ *  - NGSI-10 operations only
+ *  - except attribute domains operations
+ */
+@Service
+public class NgsiRestClient extends NgsiClient {
+
+    private static Logger logger = LoggerFactory.getLogger(NgsiRestClient.class);
+
+    private final static String basePath = "/ngsi10";
+    private final static String entitiesPath = basePath + "/contextEntities/";
+    private final static String entityTypesPath = basePath + "/contextEntityTypes/";
+    private final static String subscriptionsPath = basePath + "/contextSubscriptions/";
+    private final static String attributesPath = "/attributes/";
+    private final static String valuesPath = "/";
+
+    /*
+     * Context Entities operations
+     */
+
+    /**
+     * Append attributes to a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param appendContextElement attributes to append
+     * @return a future for an AppendContextElementResponse
+     */
+    public ListenableFuture<AppendContextElementResponse> appendContextElement(String url, HttpHeaders httpHeaders, String entityID, AppendContextElement appendContextElement) {
+        return request(HttpMethod.POST, url + entitiesPath + entityID, httpHeaders, appendContextElement, AppendContextElementResponse.class);
+    }
+
+    /**
+     * Append attributes to a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param updateContextElement attributes to update
+     * @return a future for an UpdateContextElementResponse
+     */
+    public ListenableFuture<UpdateContextElementResponse> updateContextElement(String url, HttpHeaders httpHeaders, String entityID, UpdateContextElement updateContextElement) {
+        return request(HttpMethod.PUT, url + entitiesPath + entityID, httpHeaders, updateContextElement, UpdateContextElementResponse.class);
+    }
+
+    /**
+     * Retrieve a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @return a future for a ContextElementResponse
+     */
+    public ListenableFuture<ContextElementResponse> getContextElement(String url, HttpHeaders httpHeaders, String entityID) {
+        return request(HttpMethod.GET, url + entitiesPath + entityID, httpHeaders, null, ContextElementResponse.class);
+    }
+
+    /**
+     * Delete a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @return a future for a StatusCode
+     */
+    public ListenableFuture<StatusCode> deleteContextElement(String url, HttpHeaders httpHeaders, String entityID) {
+        return request(HttpMethod.DELETE, url + entitiesPath + entityID, httpHeaders, null, StatusCode.class);
+    }
+
+    /*
+     * Context Attributes operations
+     */
+
+    /**
+     * Append an attribute to a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @param updateContextAttribute attribute to append
+     * @return a future for a StatusCode
+     */
+    public ListenableFuture<StatusCode> appendContextAttribute(String url, HttpHeaders httpHeaders, String entityID, String attributeName, UpdateContextAttribute updateContextAttribute) {
+        return request(HttpMethod.POST, url + entitiesPath + entityID + attributesPath + attributeName, httpHeaders, updateContextAttribute, StatusCode.class);
+    }
+
+    /**
+     * Update the attribute of a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @param updateContextAttribute attribute to update
+     * @return a future for a StatusCode
+     */
+    public ListenableFuture<StatusCode> updateContextAttribute(String url, HttpHeaders httpHeaders, String entityID, String attributeName, UpdateContextAttribute updateContextAttribute) {
+        return request(HttpMethod.PUT, url + entitiesPath + entityID + attributesPath + attributeName, httpHeaders, updateContextAttribute, StatusCode.class);
+    }
+
+    /**
+     * Retrieve an attribute of a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @return a future for a ContextAttributeResponse
+     */
+    public ListenableFuture<ContextAttributeResponse> getContextAttribute(String url, HttpHeaders httpHeaders, String entityID, String attributeName) {
+        return request(HttpMethod.GET, url + entitiesPath + entityID + attributesPath + attributeName, httpHeaders, null, ContextAttributeResponse.class);
+    }
+
+    /**
+     * Retrieve an attribute of a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @return a future for a StatusCode
+     */
+    public ListenableFuture<StatusCode> deleteContextAttribute(String url, HttpHeaders httpHeaders, String entityID, String attributeName) {
+        return request(HttpMethod.DELETE, url + entitiesPath + entityID + attributesPath + attributeName, httpHeaders, null, StatusCode.class);
+    }
+
+    /*
+     * Context Attribute Value Instance operations
+     */
+
+    /**
+     * Update the attribute value instance of a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @param valueID the instant ID of the attribute
+     * @param updateContextAttribute attribute values to update
+     * @return a future for a StatusCode
+     */
+    public ListenableFuture<StatusCode> updateContextAttributeValue(String url, HttpHeaders httpHeaders, String entityID, String attributeName, String valueID, UpdateContextAttribute updateContextAttribute) {
+        return request(HttpMethod.PUT, url + entitiesPath + entityID + attributesPath + attributeName + valuesPath + valueID, httpHeaders, updateContextAttribute, StatusCode.class);
+    }
+
+    /**
+     * Retrieve the attribute value instance of a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @param valueID the instant ID of the attribute
+     * @return a future for a ContextAttributeResponse
+     */
+    public ListenableFuture<ContextAttributeResponse> getContextAttributeValue(String url, HttpHeaders httpHeaders, String entityID, String attributeName, String valueID) {
+        return request(HttpMethod.GET, url + entitiesPath + entityID + attributesPath + attributeName + valuesPath + valueID, httpHeaders, null, ContextAttributeResponse.class);
+    }
+
+    /**
+     * Delete the attribute value instance of a context element
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param entityID the ID of the entity
+     * @param attributeName the name of the attribute
+     * @param valueID the instant ID of the attribute
+     * @return a future for a StatusCode
+     */
+    public ListenableFuture<StatusCode> deleteContextAttributeValue(String url, HttpHeaders httpHeaders, String entityID, String attributeName, String valueID) {
+        return request(HttpMethod.DELETE, url + entitiesPath + entityID + attributesPath + attributeName + valuesPath + valueID, httpHeaders, null, StatusCode.class);
+    }
+
+    /*
+     * Context Entity Types operations
+     */
+
+    /**
+     * Retrieve a context entity type
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param typeName the name of the entity type
+     * @return a future for a ContextElementResponse
+     */
+    public ListenableFuture<QueryContextResponse> getContextEntityType(String url, HttpHeaders httpHeaders, String typeName) {
+        return request(HttpMethod.GET, url + entityTypesPath + typeName, httpHeaders, null, QueryContextResponse.class);
+    }
+
+    /**
+     * Retrieve a context entity type attribute
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param typeName the name of the entity type
+     * @param attributeName the name of the attribute
+     * @return a future for a ContextElementResponse
+     */
+    public ListenableFuture<QueryContextResponse> getContextEntityTypeAttribute(String url, HttpHeaders httpHeaders, String typeName, String attributeName) {
+        return request(HttpMethod.GET, url + entityTypesPath + typeName + attributesPath + attributeName, httpHeaders, null, QueryContextResponse.class);
+    }
+
+    /*
+     * Subscriptions operations
+     */
+
+    /**
+     * Add a subscription
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param subscribeContext the parameters for subscription
+     * @return a future for an SubscribeContextResponse
+     */
+    public ListenableFuture<SubscribeContextResponse> appendContextSubscription(String url, HttpHeaders httpHeaders, SubscribeContext subscribeContext) {
+        return request(HttpMethod.POST, url + subscriptionsPath, httpHeaders, subscribeContext, SubscribeContextResponse.class);
+    }
+
+    /**
+     * Update a subscription
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param subscriptionID the ID of the subscription to update
+     * @param updateContextSubscription the parameters to update
+     * @return a future for an UpdateContextSubscriptionResponse
+     */
+    public ListenableFuture<UpdateContextSubscriptionResponse> updateContextSubscription(String url, HttpHeaders httpHeaders, String subscriptionID, UpdateContextSubscription updateContextSubscription) {
+        return request(HttpMethod.PUT, url + subscriptionsPath + subscriptionID, httpHeaders, updateContextSubscription, UpdateContextSubscriptionResponse.class);
+    }
+
+    /**
+     * Delete a subscription
+     * @param url the URL of the broker
+     * @param httpHeaders the HTTP header to use, or null for default
+     * @param subscriptionID the ID of the subscription to delete
+     * @return a future for an UnsubscribeContextResponse
+     */
+    public ListenableFuture<UnsubscribeContextResponse> deleteContextSubscription(String url, HttpHeaders httpHeaders, String subscriptionID) {
+        return request(HttpMethod.DELETE, url + subscriptionsPath + subscriptionID, httpHeaders, null, UnsubscribeContextResponse.class);
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/exception/MismatchIdException.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/exception/MismatchIdException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.exception;
+
+/**
+ * Exception triggered when a REST ID parameter mismatches with the ID in the request body
+ */
+public class MismatchIdException extends Exception {
+
+    private final String parameterId;
+
+    private final String bodyId;
+
+    public MismatchIdException(String parameterId, String bodyId) {
+        this.parameterId = parameterId;
+        this.bodyId = bodyId;
+    }
+
+    public String getMessage() {
+        return "mismatch id between parameter " + parameterId + " and body " + bodyId;
+    }
+
+    public String getParameterId() {
+        return parameterId;
+    }
+
+    public String getBodyId() {
+        return bodyId;
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/AppendContextElement.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/AppendContextElement.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.List;
+
+/**
+ * Request message for POST /contextEntities/{entityID}
+ */
+@JacksonXmlRootElement(localName = "appendContextElementRequest")
+public class AppendContextElement {
+
+    @JsonProperty(value = "attributes")
+    @JacksonXmlElementWrapper(localName = "contextAttributeList")
+    @JacksonXmlProperty(localName = "contextAttribute")
+    private List<ContextAttribute> attributeList;
+
+    public AppendContextElement() {
+    }
+
+    public AppendContextElement(List<ContextAttribute> attributeList) {
+        this.attributeList = attributeList;
+    }
+
+    public List<ContextAttribute> getAttributeList() {
+        return attributeList;
+    }
+
+    public void setAttributeList(List<ContextAttribute> attributeList) {
+        this.attributeList = attributeList;
+    }
+
+    @Override public String toString() {
+        return "AppendContextElement{" +
+                "attributeList=" + attributeList +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/AppendContextElementResponse.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/AppendContextElementResponse.java
@@ -29,6 +29,7 @@ public class AppendContextElementResponse {
     @JsonProperty("contextResponses")
     @JacksonXmlElementWrapper(localName = "contextResponseList")
     @JacksonXmlProperty(localName = "contextAttributeResponse")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<ContextAttributeResponse> contextAttributeResponses;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/AppendContextElementResponse.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/AppendContextElementResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.List;
+
+/**
+ * Request response for POST /contextEntities/{entityID}
+ */
+@JacksonXmlRootElement(localName = "appendContextElementResponse")
+public class AppendContextElementResponse {
+
+    @JacksonXmlProperty(localName = "entityId")
+    private EntityId entityId;
+
+    @JsonProperty("contextResponses")
+    @JacksonXmlElementWrapper(localName = "contextResponseList")
+    @JacksonXmlProperty(localName = "contextAttributeResponse")
+    private List<ContextAttributeResponse> contextAttributeResponses;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private StatusCode errorCode;
+
+    public AppendContextElementResponse() {
+    }
+
+    public EntityId getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(EntityId entityId) {
+        this.entityId = entityId;
+    }
+
+    public List<ContextAttributeResponse> getContextAttributeResponses() {
+        return contextAttributeResponses;
+    }
+
+    public void setContextAttributeResponses(List<ContextAttributeResponse> contextAttributeResponses) {
+        this.contextAttributeResponses = contextAttributeResponses;
+    }
+
+    public StatusCode getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(StatusCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return "AppendContextElementResponse{" +
+                "entityId=" + entityId +
+                ", contextAttributeResponses=" + contextAttributeResponses +
+                ", errorCode=" + errorCode +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextAttribute.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextAttribute.java
@@ -33,7 +33,7 @@ public class ContextAttribute {
     @JsonProperty("metadatas")
     @JacksonXmlElementWrapper(localName = "metadata")
     @JacksonXmlProperty(localName = "contextMetadata")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<ContextMetadata> metadata;
 
     public ContextAttribute() {

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextAttribute.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextAttribute.java
@@ -8,6 +8,7 @@
 
 package com.orange.ngsi.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -32,6 +33,7 @@ public class ContextAttribute {
     @JsonProperty("metadatas")
     @JacksonXmlElementWrapper(localName = "metadata")
     @JacksonXmlProperty(localName = "contextMetadata")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<ContextMetadata> metadata;
 
     public ContextAttribute() {

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextAttributeResponse.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextAttributeResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.util.List;
+
+/**
+ * Response to GET /contextEntities/{entityID}/attributes/{attributeName}
+ */
+public class ContextAttributeResponse {
+
+    @JsonProperty("attributes")
+    @JacksonXmlElementWrapper(localName = "contextAttributeList")
+    @JacksonXmlProperty(localName = "contextAttribute")
+    private List<ContextAttribute> contextAttributeList;
+
+    private StatusCode statusCode;
+
+    public ContextAttributeResponse() {
+    }
+
+    public List<ContextAttribute> getContextAttributeList() {
+        return contextAttributeList;
+    }
+
+    public void setContextAttributeList(List<ContextAttribute> contextAttributeList) {
+        this.contextAttributeList = contextAttributeList;
+    }
+
+    public StatusCode getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(StatusCode statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public String toString() {
+        return "ContextAttributeResponse{" +
+                "contextAttributeList=" + contextAttributeList +
+                ", statusCode=" + statusCode +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextElement.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/ContextElement.java
@@ -25,6 +25,7 @@ public class ContextElement {
 
     private EntityId entityId;
 
+    @JsonProperty("attributes")
     @JacksonXmlElementWrapper(localName = "contextAttributeList")
     @JacksonXmlProperty(localName = "contextAttribute")
     private List<ContextAttribute> contextAttributeList;

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/EntityIdMixIn.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/EntityIdMixIn.java
@@ -8,13 +8,11 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Mixin annotations for the JSON (de)serialization for ContextElement
+ * Mixin annotation for the JSON (de)serialization for ContextElement/AppendContextElementResponse
  */
-public class ContextElementMixIn {
+public class EntityIdMixIn {
 
+    // Mix EntityId properties in its parent class for JSON only
     @JsonUnwrapped
     EntityId entityId;
-
-    @JsonProperty("attributes")
-    List<ContextAttribute> contextAttributeList;
 }

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/StatusCode.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/StatusCode.java
@@ -11,10 +11,12 @@ package com.orange.ngsi.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * Created by pborscia on 04/06/2015.
  */
+@JacksonXmlRootElement(localName = "statusCode")
 public class StatusCode {
 
     private String code;

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextAttribute.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextAttribute.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.List;
+
+/**
+ * Request for POST/PUT /contextEntities/{entityID}/attributes/{attributeName}
+ */
+@JacksonXmlRootElement(localName = "updateContextAttributeRequest")
+public class UpdateContextAttribute {
+
+    @JsonUnwrapped
+    ContextAttribute attribute;
+
+    public UpdateContextAttribute() {
+    }
+
+    public ContextAttribute getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(ContextAttribute attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateContextAttribute{" +
+                "attribute=" + attribute +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextElement.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextElement.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.List;
+
+/**
+ * Request message for PUT /contextEntities/{entityID}
+ */
+@JacksonXmlRootElement(localName = "updateContextElementRequest")
+public class UpdateContextElement {
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    String attributeDomainName;
+
+    @JsonProperty(value = "attributes")
+    @JacksonXmlElementWrapper(localName="contextAttributeList")
+    @JacksonXmlProperty(localName="contextAttribute")
+    List<ContextAttribute> contextAttributes;
+
+    public UpdateContextElement() {
+    }
+
+    public String getAttributeDomainName() {
+        return attributeDomainName;
+    }
+
+    public void setAttributeDomainName(String attributeDomainName) {
+        this.attributeDomainName = attributeDomainName;
+    }
+
+    public List<ContextAttribute> getContextAttributes() {
+        return contextAttributes;
+    }
+
+    public void setContextAttributes(List<ContextAttribute> contextAttributes) {
+        this.contextAttributes = contextAttributes;
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateContextElement{" +
+                "attributeDomainName='" + attributeDomainName + '\'' +
+                ", contextAttributes=" + contextAttributes +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextElementResponse.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextElementResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.List;
+
+/**
+ * Request response for PUT /contextEntities/{entityID}
+ */
+@JacksonXmlRootElement(localName = "updateContextElementResponse")
+public class UpdateContextElementResponse {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    StatusCode errorCode;
+
+    @JsonProperty("contextResponses")
+    @JacksonXmlElementWrapper(localName = "contextResponseList")
+    @JacksonXmlProperty(localName = "contextAttributeResponse")
+    List<ContextAttributeResponse> contextAttributeResponses;
+
+    public UpdateContextElementResponse() {
+    }
+
+    public StatusCode getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(StatusCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public List<ContextAttributeResponse> getContextAttributeResponses() {
+        return contextAttributeResponses;
+    }
+
+    public void setContextAttributeResponses(List<ContextAttributeResponse> contextAttributeResponses) {
+        this.contextAttributeResponses = contextAttributeResponses;
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateContextElementResponse{" +
+                "errorCode=" + errorCode +
+                ", contextAttributeResponses=" + contextAttributeResponses +
+                '}';
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextElementResponse.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/model/UpdateContextElementResponse.java
@@ -28,6 +28,7 @@ public class UpdateContextElementResponse {
     @JsonProperty("contextResponses")
     @JacksonXmlElementWrapper(localName = "contextResponseList")
     @JacksonXmlProperty(localName = "contextAttributeResponse")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     List<ContextAttributeResponse> contextAttributeResponses;
 
     public UpdateContextElementResponse() {

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRESTBaseController.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRESTBaseController.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.server;
+
+import com.orange.ngsi.ProtocolRegistry;
+import com.orange.ngsi.exception.MismatchIdException;
+import com.orange.ngsi.exception.MissingRequestParameterException;
+import com.orange.ngsi.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+/**
+ * Controller for the NGSI 9/10 convenient REST requests
+ * Deviation from standard:
+ *  - no support for attributeDomains requests
+ *  - only NGSI 10 REST requests are supported
+ */
+public class NgsiRESTBaseController {
+
+    private static Logger logger = LoggerFactory.getLogger(NgsiRESTBaseController.class);
+
+    @Autowired
+    private NgsiValidation ngsiValidation;
+
+    @Autowired
+    private ProtocolRegistry protocolRegistry;
+
+    /* Context Entities */
+
+    @RequestMapping(method = RequestMethod.POST,
+            value = {"/contextEntities/{entityID}", "/contextEntities/{entityID}/attributes"},
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<AppendContextElementResponse> appendContextElement(
+            @PathVariable String entityID,
+            @RequestBody AppendContextElement appendContextElement,
+            HttpServletRequest httpServletRequest) throws Exception {
+        ngsiValidation.checkAppendContextElement(appendContextElement);
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(appendContextElement(entityID, appendContextElement), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.PUT,
+            value = {"/contextEntities/{entityID}", "/contextEntities/{entityID}/attributes"},
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<UpdateContextElementResponse> updateContextEntity(@PathVariable String entityID,
+            @RequestBody UpdateContextElement updateContextElement,
+            HttpServletRequest httpServletRequest) throws Exception {
+        ngsiValidation.checkUpdateContextElement(updateContextElement);
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(updateContextElement(entityID, updateContextElement), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.GET,
+            value = {"/contextEntities/{entityID}", "/contextEntities/{entityID}/attributes"})
+    final public ResponseEntity<ContextElementResponse> getContextEntity(@PathVariable String entityID,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(getContextElement(entityID), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE,
+            value = {"/contextEntities/{entityID}", "/contextEntities/{entityID}/attributes"})
+    final public ResponseEntity<StatusCode> deleteContextEntity(@PathVariable String entityID,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(deleteContextElement(entityID), HttpStatus.OK);
+    }
+
+    /* Context Attributes */
+
+    @RequestMapping(method = RequestMethod.POST,
+            value = "/contextEntities/{entityID}/attributes/{attributeName}",
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<StatusCode> appendContextAttributeValue(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            @RequestBody UpdateContextAttribute updateContextAttribute,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(appendContextAttribute(entityID, attributeName, updateContextAttribute), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.PUT,
+            value = {"/contextEntities/{entityID}/attributes/{attributeName}",
+                     "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}"},
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<StatusCode> updateContextAttribute(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            @PathVariable Optional<String> valueID,
+            @RequestBody UpdateContextAttribute updateContextAttribute,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(updateContextAttribute(entityID, attributeName, valueID, updateContextAttribute), HttpStatus.OK);
+    }
+
+    @RequestMapping( method = RequestMethod.GET,
+            value = {"/contextEntities/{entityID}/attributes/{attributeName}",
+                     "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}"})
+    final public ResponseEntity<ContextAttributeResponse> getContextAttribute(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            @PathVariable Optional<String> valueID,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(getContextAttribute(entityID, attributeName, valueID), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE,
+            value = {"/contextEntities/{entityID}/attributes/{attributeName}",
+                     "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}"})
+    final public ResponseEntity<StatusCode> deleteContextAttribute(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            @PathVariable Optional<String> valueID,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(deleteContextAttribute(entityID, attributeName, valueID), HttpStatus.OK);
+    }
+
+    /* Entity types */
+
+    @RequestMapping(method = RequestMethod.GET,
+            value = {"/contextEntityTypes/{typeName}",
+                     "/contextEntityTypes/{typeName}/attributes",
+                     "/contextEntityTypes/{typeName}/attributes/{attributeName}"})
+    final public ResponseEntity<QueryContextResponse> getContextEntityTypes(
+            @PathVariable String typeName,
+            @PathVariable Optional<String> attributeName,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(getContextEntitiesType(typeName, attributeName), HttpStatus.OK);
+    }
+
+    /* Subscriptions */
+
+    @RequestMapping(method = RequestMethod.POST,
+            value = "/contextSubscriptions",
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<SubscribeContextResponse> createSubscription(
+            @RequestBody SubscribeContext subscribeContext,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        ngsiValidation.checkSubscribeContext(subscribeContext);
+        return new ResponseEntity<>(createSubscription(subscribeContext), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.PUT,
+            value = "/contextSubscriptions/{subscriptionID}",
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<UpdateContextSubscriptionResponse> updateSubscription(
+            @PathVariable String subscriptionID,
+            @RequestBody UpdateContextSubscription updateContextSubscription,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        ngsiValidation.checkUpdateSubscription(subscriptionID, updateContextSubscription);
+        return new ResponseEntity<>(updateSubscription(updateContextSubscription), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE,
+            value = "/contextSubscriptions/{subscriptionID}")
+    final public ResponseEntity<UnsubscribeContextResponse> deleteSubscription(
+            @PathVariable String subscriptionID,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(deleteSubscription(subscriptionID), HttpStatus.OK);
+    }
+
+    /*
+     * Exception handling
+     */
+
+    @ExceptionHandler({MissingRequestParameterException.class})
+    public ResponseEntity<Object> missingParameter(HttpServletRequest req, MissingRequestParameterException missingException) {
+        logger.error("Missing parameter: {}", missingException.getParameterName());
+        StatusCode statusCode = new StatusCode(CodeEnum.CODE_471, missingException.getParameterName(), missingException.getParameterType());
+        return errorResponse(req.getRequestURI(), statusCode);
+    }
+
+    @ExceptionHandler({HttpMessageNotReadableException.class})
+    public ResponseEntity<Object> messageNotReadableExceptionHandler(HttpServletRequest req, HttpMessageNotReadableException exception) {
+        logger.error("Message not readable: {}", exception.toString());
+        return errorResponse(req.getRequestURI(), new StatusCode(CodeEnum.CODE_400));
+    }
+
+    @ExceptionHandler({UnsupportedOperationException.class})
+    public ResponseEntity<Object> unsupportedOperation(HttpServletRequest req, UnsupportedOperationException exception) {
+        logger.error("Unsupported operation: {}", exception.toString());
+        return errorResponse(req.getRequestURI(), new StatusCode(CodeEnum.CODE_403));
+    }
+
+    @ExceptionHandler({MismatchIdException.class})
+    public ResponseEntity<Object> mismatchIdException(HttpServletRequest req, MismatchIdException exception) {
+        logger.error("Mismatch id: {}", exception.toString());
+        return errorResponse(req.getRequestURI(), new StatusCode(CodeEnum.CODE_472, "subscriptionID"));
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> exceptionHandler(HttpServletRequest req, Exception exception) {
+        logger.error("Exception handler: {}", exception);
+        return errorResponse(req.getRequestURI(), new StatusCode(CodeEnum.CODE_500));
+    }
+
+    /*
+     * Methods overridden by child classes to handle the NGSI v1 convenient REST requests
+     */
+
+    protected AppendContextElementResponse appendContextElement(String entityID,
+            AppendContextElement appendContextElement) throws Exception {
+        throw new UnsupportedOperationException("appendContextElement");
+    }
+
+    protected UpdateContextElementResponse updateContextElement(String entityID,
+            UpdateContextElement updateContextElement) throws Exception {
+        throw new UnsupportedOperationException("updateContextElement");
+    }
+
+    protected ContextElementResponse getContextElement(String entityID) throws Exception {
+        throw new UnsupportedOperationException("getContextElement");
+    }
+
+    protected StatusCode deleteContextElement(String entityID) throws Exception {
+        throw new UnsupportedOperationException("deleteContextElement");
+    }
+
+    protected StatusCode appendContextAttribute(String entityID, String attributeName,
+            UpdateContextAttribute updateContextAttribute) throws Exception {
+        throw new UnsupportedOperationException("appendContextAttribute");
+    }
+
+    protected StatusCode updateContextAttribute(final String entityID, String attributeName, Optional<String> valueID,
+            UpdateContextAttribute updateContextElementRequest) throws Exception {
+        throw new UnsupportedOperationException("updateContextAttribute");
+    }
+
+    protected ContextAttributeResponse getContextAttribute( String entityID, String attributeName, Optional<String> valueID) throws Exception {
+        throw new UnsupportedOperationException("getContextAttribute");
+    }
+
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName, Optional<String> valueID) throws Exception {
+        throw new UnsupportedOperationException("deleteContextAttribute");
+    }
+
+    protected QueryContextResponse getContextEntitiesType(String typeName, Optional<String> attributeName) throws Exception {
+        throw new UnsupportedOperationException("getContextEntitiesType");
+    }
+
+    protected SubscribeContextResponse createSubscription(final SubscribeContext subscribeContext) throws Exception {
+        throw new UnsupportedOperationException("createSubscription");
+    }
+
+    protected UpdateContextSubscriptionResponse updateSubscription(
+            UpdateContextSubscription updateContextSubscription) throws Exception {
+        throw new UnsupportedOperationException("updateSubscription");
+    }
+
+    protected UnsubscribeContextResponse deleteSubscription(String subscriptionID) throws Exception {
+        throw new UnsupportedOperationException("deleteSubscription");
+    }
+
+    /*
+     * Other methods for use by child classes.
+     */
+
+    /**
+     * Response for request error. NGSI requests require custom responses with 200 OK HTTP response code.
+     */
+    protected ResponseEntity<Object> errorResponse(String path, StatusCode statusCode) {
+        return new ResponseEntity<>(statusCode, HttpStatus.OK);
+    }
+
+    /**
+     * Register the host to protocolRegistry if it supports JSON
+     * @param httpServletRequest the request
+     */
+    private void registerIntoDispatcher(HttpServletRequest httpServletRequest) {
+        String uri = httpServletRequest.getRequestURI();
+
+        // Use Accept or fallback to Content-Type if not defined
+        String accept = httpServletRequest.getHeader("Accept");
+        if (accept == null) {
+            accept = httpServletRequest.getHeader("Content-Type");
+        }
+
+        if (accept != null && accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
+            protocolRegistry.registerHost(uri, true);
+        }
+    }
+}

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
@@ -129,34 +129,34 @@ public class NgsiRestBaseController {
     @RequestMapping(method = RequestMethod.PUT,
             value = "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}",
             consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
-    final public ResponseEntity<StatusCode> updateContextAttribute(@PathVariable String entityID,
+    final public ResponseEntity<StatusCode> updateContextAttributeValue(@PathVariable String entityID,
             @PathVariable String attributeName,
             @PathVariable String valueID,
             @RequestBody UpdateContextAttribute updateContextAttribute,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
         ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, valueID, updateContextAttribute);
-        return new ResponseEntity<>(updateContextAttribute(entityID, attributeName, valueID, updateContextAttribute), HttpStatus.OK);
+        return new ResponseEntity<>(updateContextAttributeValue(entityID, attributeName, valueID, updateContextAttribute), HttpStatus.OK);
     }
 
     @RequestMapping( method = RequestMethod.GET,
             value = "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}")
-    final public ResponseEntity<ContextAttributeResponse> getContextAttribute(@PathVariable String entityID,
+    final public ResponseEntity<ContextAttributeResponse> getContextAttributeValue(@PathVariable String entityID,
             @PathVariable String attributeName,
             @PathVariable String valueID,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
-        return new ResponseEntity<>(getContextAttribute(entityID, attributeName, valueID), HttpStatus.OK);
+        return new ResponseEntity<>(getContextAttributeValue(entityID, attributeName, valueID), HttpStatus.OK);
     }
 
     @RequestMapping(method = RequestMethod.DELETE,
             value = "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}")
-    final public ResponseEntity<StatusCode> deleteContextAttribute(@PathVariable String entityID,
+    final public ResponseEntity<StatusCode> deleteContextAttributeValue(@PathVariable String entityID,
             @PathVariable String attributeName,
             @PathVariable String valueID,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
-        return new ResponseEntity<>(deleteContextAttribute(entityID, attributeName, valueID), HttpStatus.OK);
+        return new ResponseEntity<>(deleteContextAttributeValue(entityID, attributeName, valueID), HttpStatus.OK);
     }
 
     /* Entity types */
@@ -241,7 +241,7 @@ public class NgsiRestBaseController {
     @ExceptionHandler({MismatchIdException.class})
     public ResponseEntity<Object> mismatchIdException(HttpServletRequest req, MismatchIdException exception) {
         logger.error("Mismatch id: {}", exception.toString());
-        return errorResponse(req.getRequestURI(), new StatusCode(CodeEnum.CODE_472, "subscriptionID"));
+        return errorResponse(req.getRequestURI(), new StatusCode(CodeEnum.CODE_472, exception.getParameterId()));
     }
 
     @ExceptionHandler({Exception.class})
@@ -282,16 +282,7 @@ public class NgsiRestBaseController {
         throw new UnsupportedOperationException("updateContextAttribute");
     }
 
-    protected StatusCode updateContextAttribute(final String entityID, String attributeName, String valueID,
-            UpdateContextAttribute updateContextElementRequest) throws Exception {
-        throw new UnsupportedOperationException("updateContextAttribute");
-    }
-
     protected ContextAttributeResponse getContextAttribute( String entityID, String attributeName) throws Exception {
-        throw new UnsupportedOperationException("getContextAttribute");
-    }
-
-    protected ContextAttributeResponse getContextAttribute( String entityID, String attributeName, String valueID) throws Exception {
         throw new UnsupportedOperationException("getContextAttribute");
     }
 
@@ -299,8 +290,17 @@ public class NgsiRestBaseController {
         throw new UnsupportedOperationException("deleteContextAttribute");
     }
 
-    protected StatusCode deleteContextAttribute(String entityID, String attributeName, String valueID) throws Exception {
-        throw new UnsupportedOperationException("deleteContextAttribute");
+    protected StatusCode updateContextAttributeValue(final String entityID, String attributeName, String valueID,
+            UpdateContextAttribute updateContextElementRequest) throws Exception {
+        throw new UnsupportedOperationException("updateContextAttributeValue");
+    }
+
+    protected ContextAttributeResponse getContextAttributeValue( String entityID, String attributeName, String valueID) throws Exception {
+        throw new UnsupportedOperationException("getContextAttributeValue");
+    }
+
+    protected StatusCode deleteContextAttributeValue(String entityID, String attributeName, String valueID) throws Exception {
+        throw new UnsupportedOperationException("deleteContextAttributeValue");
     }
 
     protected QueryContextResponse getContextEntitiesType(String typeName) throws Exception {

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
@@ -30,9 +30,9 @@ import java.util.Optional;
  *  - no support for attributeDomains requests
  *  - only NGSI 10 REST requests are supported
  */
-public class NgsiRESTBaseController {
+public class NgsiRestBaseController {
 
-    private static Logger logger = LoggerFactory.getLogger(NgsiRESTBaseController.class);
+    private static Logger logger = LoggerFactory.getLogger(NgsiRestBaseController.class);
 
     @Autowired
     private NgsiValidation ngsiValidation;

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
@@ -22,7 +22,6 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Optional;
 
 /**
  * Controller for the NGSI 9/10 convenient REST requests
@@ -91,41 +90,70 @@ public class NgsiRestBaseController {
             @RequestBody UpdateContextAttribute updateContextAttribute,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
-        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, Optional.empty(), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, null, updateContextAttribute);
         return new ResponseEntity<>(appendContextAttribute(entityID, attributeName, updateContextAttribute), HttpStatus.OK);
     }
 
     @RequestMapping(method = RequestMethod.PUT,
-            value = {"/contextEntities/{entityID}/attributes/{attributeName}",
-                     "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}"},
+            value = "/contextEntities/{entityID}/attributes/{attributeName}",
             consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     final public ResponseEntity<StatusCode> updateContextAttribute(@PathVariable String entityID,
             @PathVariable String attributeName,
-            @PathVariable Optional<String> valueID,
             @RequestBody UpdateContextAttribute updateContextAttribute,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
-        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, Optional.empty(), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, null, updateContextAttribute);
+        return new ResponseEntity<>(updateContextAttribute(entityID, attributeName, updateContextAttribute), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.GET,
+            value = "/contextEntities/{entityID}/attributes/{attributeName}")
+    final public ResponseEntity<ContextAttributeResponse> getContextAttribute(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(getContextAttribute(entityID, attributeName), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE,
+            value = "/contextEntities/{entityID}/attributes/{attributeName}")
+    final public ResponseEntity<StatusCode> deleteContextAttribute(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(deleteContextAttribute(entityID, attributeName), HttpStatus.OK);
+    }
+
+    /* Context Attributes Value instances */
+
+    @RequestMapping(method = RequestMethod.PUT,
+            value = "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}",
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    final public ResponseEntity<StatusCode> updateContextAttribute(@PathVariable String entityID,
+            @PathVariable String attributeName,
+            @PathVariable String valueID,
+            @RequestBody UpdateContextAttribute updateContextAttribute,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, valueID, updateContextAttribute);
         return new ResponseEntity<>(updateContextAttribute(entityID, attributeName, valueID, updateContextAttribute), HttpStatus.OK);
     }
 
     @RequestMapping( method = RequestMethod.GET,
-            value = {"/contextEntities/{entityID}/attributes/{attributeName}",
-                     "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}"})
+            value = "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}")
     final public ResponseEntity<ContextAttributeResponse> getContextAttribute(@PathVariable String entityID,
             @PathVariable String attributeName,
-            @PathVariable Optional<String> valueID,
+            @PathVariable String valueID,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
         return new ResponseEntity<>(getContextAttribute(entityID, attributeName, valueID), HttpStatus.OK);
     }
 
     @RequestMapping(method = RequestMethod.DELETE,
-            value = {"/contextEntities/{entityID}/attributes/{attributeName}",
-                     "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}"})
+            value = "/contextEntities/{entityID}/attributes/{attributeName}/{valueID}")
     final public ResponseEntity<StatusCode> deleteContextAttribute(@PathVariable String entityID,
             @PathVariable String attributeName,
-            @PathVariable Optional<String> valueID,
+            @PathVariable String valueID,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
         return new ResponseEntity<>(deleteContextAttribute(entityID, attributeName, valueID), HttpStatus.OK);
@@ -135,11 +163,19 @@ public class NgsiRestBaseController {
 
     @RequestMapping(method = RequestMethod.GET,
             value = {"/contextEntityTypes/{typeName}",
-                     "/contextEntityTypes/{typeName}/attributes",
-                     "/contextEntityTypes/{typeName}/attributes/{attributeName}"})
+                    "/contextEntityTypes/{typeName}/attributes"})
     final public ResponseEntity<QueryContextResponse> getContextEntityTypes(
             @PathVariable String typeName,
-            @PathVariable Optional<String> attributeName,
+            HttpServletRequest httpServletRequest) throws Exception {
+        registerIntoDispatcher(httpServletRequest);
+        return new ResponseEntity<>(getContextEntitiesType(typeName), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.GET,
+            value = "/contextEntityTypes/{typeName}/attributes/{attributeName}")
+    final public ResponseEntity<QueryContextResponse> getContextEntityTypes(
+            @PathVariable String typeName,
+            @PathVariable String attributeName,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
         return new ResponseEntity<>(getContextEntitiesType(typeName, attributeName), HttpStatus.OK);
@@ -241,20 +277,37 @@ public class NgsiRestBaseController {
         throw new UnsupportedOperationException("appendContextAttribute");
     }
 
-    protected StatusCode updateContextAttribute(final String entityID, String attributeName, Optional<String> valueID,
+    protected StatusCode updateContextAttribute(final String entityID, String attributeName,
             UpdateContextAttribute updateContextElementRequest) throws Exception {
         throw new UnsupportedOperationException("updateContextAttribute");
     }
 
-    protected ContextAttributeResponse getContextAttribute( String entityID, String attributeName, Optional<String> valueID) throws Exception {
+    protected StatusCode updateContextAttribute(final String entityID, String attributeName, String valueID,
+            UpdateContextAttribute updateContextElementRequest) throws Exception {
+        throw new UnsupportedOperationException("updateContextAttribute");
+    }
+
+    protected ContextAttributeResponse getContextAttribute( String entityID, String attributeName) throws Exception {
         throw new UnsupportedOperationException("getContextAttribute");
     }
 
-    protected StatusCode deleteContextAttribute(String entityID, String attributeName, Optional<String> valueID) throws Exception {
+    protected ContextAttributeResponse getContextAttribute( String entityID, String attributeName, String valueID) throws Exception {
+        throw new UnsupportedOperationException("getContextAttribute");
+    }
+
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName) throws Exception {
         throw new UnsupportedOperationException("deleteContextAttribute");
     }
 
-    protected QueryContextResponse getContextEntitiesType(String typeName, Optional<String> attributeName) throws Exception {
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName, String valueID) throws Exception {
+        throw new UnsupportedOperationException("deleteContextAttribute");
+    }
+
+    protected QueryContextResponse getContextEntitiesType(String typeName) throws Exception {
+        throw new UnsupportedOperationException("getContextEntitiesType");
+    }
+
+    protected QueryContextResponse getContextEntitiesType(String typeName, String attributeName) throws Exception {
         throw new UnsupportedOperationException("getContextEntitiesType");
     }
 
@@ -279,7 +332,7 @@ public class NgsiRestBaseController {
      * Response for request error. NGSI requests require custom responses with 200 OK HTTP response code.
      */
     protected ResponseEntity<Object> errorResponse(String path, StatusCode statusCode) {
-        return new ResponseEntity<>(statusCode, HttpStatus.OK);
+        return new ResponseEntity<Object>(statusCode, HttpStatus.OK);
     }
 
     /**

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiRestBaseController.java
@@ -91,6 +91,7 @@ public class NgsiRestBaseController {
             @RequestBody UpdateContextAttribute updateContextAttribute,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
+        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, Optional.empty(), updateContextAttribute);
         return new ResponseEntity<>(appendContextAttribute(entityID, attributeName, updateContextAttribute), HttpStatus.OK);
     }
 
@@ -104,6 +105,7 @@ public class NgsiRestBaseController {
             @RequestBody UpdateContextAttribute updateContextAttribute,
             HttpServletRequest httpServletRequest) throws Exception {
         registerIntoDispatcher(httpServletRequest);
+        ngsiValidation.checkUpdateContextAttribute(entityID, attributeName, Optional.empty(), updateContextAttribute);
         return new ResponseEntity<>(updateContextAttribute(entityID, attributeName, valueID, updateContextAttribute), HttpStatus.OK);
     }
 

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiValidation.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiValidation.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 
 
@@ -118,6 +119,42 @@ public class NgsiValidation {
     public void checkUpdateContextElement(UpdateContextElement updateContextElement) throws MissingRequestParameterException {
         if (nullOrEmpty(updateContextElement.getContextAttributes())) {
             throw new MissingRequestParameterException("contextAttributes", "List<ContextAttribute>");
+        }
+    }
+
+    public void checkUpdateContextAttribute(String entityID, String attributeName, Optional<String> valueID, UpdateContextAttribute updateContextAttribute)
+            throws MissingRequestParameterException, MismatchIdException {
+        if (nullOrEmpty(entityID)) {
+            throw new MissingRequestParameterException("entityID", "string");
+        }
+        if (nullOrEmpty(attributeName)) {
+            throw new MissingRequestParameterException("attributeName", "string");
+        }
+        if (updateContextAttribute == null || updateContextAttribute.getAttribute() == null) {
+            throw new MissingRequestParameterException("attribute", "ContextAttribute");
+        }
+        // Check attribute name matching
+        if (!attributeName.equals(updateContextAttribute.getAttribute().getName())) {
+            throw new MismatchIdException(attributeName, updateContextAttribute.getAttribute().getName());
+        }
+        // Check optional valueID matching
+        if (valueID.isPresent()) {
+            if (nullOrEmpty(valueID.get())) { // tests just emptiness
+                throw new MissingRequestParameterException("valueID", "string");
+            }
+            if (updateContextAttribute.getAttribute().getMetadata() == null) {
+                throw new MissingRequestParameterException("metadata", "Metadata");
+            }
+            // Check Metadata ID exists and equals valueID
+            for (ContextMetadata metadata : updateContextAttribute.getAttribute().getMetadata()) {
+                if ("ID".equals(metadata.getName())) {
+                    if (valueID.get().equals(metadata.getValue())) {
+                        return; // ! \\ Early return !
+                    }
+                    throw new MismatchIdException(valueID.get(), String.valueOf(metadata.getValue()));
+                }
+            }
+            throw new MissingRequestParameterException("ID", "Metadata ID");
         }
     }
 

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiValidation.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiValidation.java
@@ -122,7 +122,7 @@ public class NgsiValidation {
         }
     }
 
-    public void checkUpdateContextAttribute(String entityID, String attributeName, Optional<String> valueID, UpdateContextAttribute updateContextAttribute)
+    public void checkUpdateContextAttribute(String entityID, String attributeName, String valueID, UpdateContextAttribute updateContextAttribute)
             throws MissingRequestParameterException, MismatchIdException {
         if (nullOrEmpty(entityID)) {
             throw new MissingRequestParameterException("entityID", "string");
@@ -138,8 +138,8 @@ public class NgsiValidation {
             throw new MismatchIdException(attributeName, updateContextAttribute.getAttribute().getName());
         }
         // Check optional valueID matching
-        if (valueID.isPresent()) {
-            if (nullOrEmpty(valueID.get())) { // tests just emptiness
+        if (valueID != null) {
+            if (nullOrEmpty(valueID)) { // tests just emptiness
                 throw new MissingRequestParameterException("valueID", "string");
             }
             if (updateContextAttribute.getAttribute().getMetadata() == null) {
@@ -148,10 +148,10 @@ public class NgsiValidation {
             // Check Metadata ID exists and equals valueID
             for (ContextMetadata metadata : updateContextAttribute.getAttribute().getMetadata()) {
                 if ("ID".equals(metadata.getName())) {
-                    if (valueID.get().equals(metadata.getValue())) {
+                    if (valueID.equals(metadata.getValue())) {
                         return; // ! \\ Early return !
                     }
-                    throw new MismatchIdException(valueID.get(), String.valueOf(metadata.getValue()));
+                    throw new MismatchIdException(valueID, String.valueOf(metadata.getValue()));
                 }
             }
             throw new MissingRequestParameterException("ID", "Metadata ID");

--- a/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiValidation.java
+++ b/cepheus-ngsi/src/main/java/com/orange/ngsi/server/NgsiValidation.java
@@ -1,6 +1,8 @@
 package com.orange.ngsi.server;
 
+import com.orange.ngsi.exception.MismatchIdException;
 import com.orange.ngsi.exception.MissingRequestParameterException;
+import com.orange.ngsi.exception.UnsupportedOperationException;
 import com.orange.ngsi.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,6 +109,25 @@ public class NgsiValidation {
             }
         }
     }
+    public void checkAppendContextElement(AppendContextElement appendContextElement) throws MissingRequestParameterException {
+        if (nullOrEmpty(appendContextElement.getAttributeList())) {
+            throw new MissingRequestParameterException("contextAttributes", "List<ContextAttribute>");
+        }
+    }
+
+    public void checkUpdateContextElement(UpdateContextElement updateContextElement) throws MissingRequestParameterException {
+        if (nullOrEmpty(updateContextElement.getContextAttributes())) {
+            throw new MissingRequestParameterException("contextAttributes", "List<ContextAttribute>");
+        }
+    }
+
+    public void checkUpdateSubscription(String subscriptionID, UpdateContextSubscription updateContextSubscription) throws MissingRequestParameterException, MismatchIdException {
+        checkUpdateContextSubscription(updateContextSubscription);
+        // Check that subscriptionID parameter is equal to the one given in the message body
+        if (!subscriptionID.equals(updateContextSubscription.getSubscriptionId())) {
+            throw new MismatchIdException(subscriptionID, updateContextSubscription.getSubscriptionId());
+        }
+    }
 
     private void checkContextElementResponse(ContextElementResponse contextElementResponse) throws MissingRequestParameterException {
 
@@ -126,7 +147,7 @@ public class NgsiValidation {
         }
         checkEntityId(contextElement.getEntityId());
         if (nullOrEmpty(contextElement.getContextAttributeList())) {
-            throw new MissingRequestParameterException("contextAttributes", "List<ContextAttribut>");
+            throw new MissingRequestParameterException("contextAttributes", "List<ContextAttribute>");
         }
     }
 

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/Util.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/Util.java
@@ -51,7 +51,7 @@ public class Util {
         return updateContext;
     }
 
-    static public ContextElementResponse createUpdateContextElement() {
+    static public ContextElementResponse createContextElementResponseTemperature() {
         ContextElementResponse contextElementResponse = new ContextElementResponse();
         contextElementResponse.setContextElement(createTemperatureContextElement(0));
         contextElementResponse.setStatusCode(new StatusCode(CODE_200));
@@ -60,7 +60,7 @@ public class Util {
 
     static public UpdateContextResponse createUpdateContextResponseTempSensor() throws URISyntaxException {
         UpdateContextResponse updateContextResponse = new UpdateContextResponse();
-        updateContextResponse.setContextElementResponses(Collections.singletonList(createUpdateContextElement()));
+        updateContextResponse.setContextElementResponses(Collections.singletonList(createContextElementResponseTemperature()));
         return updateContextResponse;
     }
 

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/Util.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/Util.java
@@ -51,14 +51,16 @@ public class Util {
         return updateContext;
     }
 
-    static public UpdateContextResponse createUpdateContextResponseTempSensor() throws URISyntaxException {
+    static public ContextElementResponse createUpdateContextElement() {
         ContextElementResponse contextElementResponse = new ContextElementResponse();
         contextElementResponse.setContextElement(createTemperatureContextElement(0));
         contextElementResponse.setStatusCode(new StatusCode(CODE_200));
+        return contextElementResponse;
+    }
 
+    static public UpdateContextResponse createUpdateContextResponseTempSensor() throws URISyntaxException {
         UpdateContextResponse updateContextResponse = new UpdateContextResponse();
-        updateContextResponse.setErrorCode(new StatusCode(CODE_200));
-        updateContextResponse.setContextElementResponses(Collections.singletonList(contextElementResponse));
+        updateContextResponse.setContextElementResponses(Collections.singletonList(createUpdateContextElement()));
         return updateContextResponse;
     }
 
@@ -161,6 +163,13 @@ public class Util {
         return updateContextSubscriptionResponse;
     }
 
+    static public UnsubscribeContextResponse createUnsubscribeContextSubscriptionResponseTemperature() {
+        UnsubscribeContextResponse unsubscribeContextResponse = new UnsubscribeContextResponse();
+        unsubscribeContextResponse.setStatusCode(new StatusCode(CODE_200));
+        unsubscribeContextResponse.setSubscriptionId("12345678");
+        return unsubscribeContextResponse;
+    }
+
     static public RegisterContext createRegisterContextTemperature() throws URISyntaxException {
         RegisterContext registerContext = new RegisterContext();
 
@@ -201,6 +210,51 @@ public class Util {
         ContextElementResponse contextElementResponse = new ContextElementResponse(createTemperatureContextElement(0), new StatusCode(CODE_200));
         queryContextResponse.setContextElementResponses(Collections.singletonList(contextElementResponse));
         return queryContextResponse;
+    }
+
+    static public AppendContextElement createAppendContextElementTemperature() {
+        AppendContextElement appendContextElement = new AppendContextElement();
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        appendContextElement.setAttributeList(Collections.singletonList(contextAttribute));
+        return appendContextElement;
+    }
+
+    static public ContextAttributeResponse createContextAttributeResponseTemperature() {
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        ContextAttributeResponse contextAttributeResponse = new ContextAttributeResponse();
+        contextAttributeResponse.setContextAttributeList(Collections.singletonList(contextAttribute));
+        contextAttributeResponse.setStatusCode(new StatusCode(CODE_200));
+        return contextAttributeResponse;
+    }
+
+    static public AppendContextElementResponse createAppendContextElementResponseTemperature() {
+        AppendContextElementResponse appendContextElementResponse = new AppendContextElementResponse();
+        appendContextElementResponse.setContextAttributeResponses(Collections.singletonList(createContextAttributeResponseTemperature()));
+        return appendContextElementResponse;
+    }
+
+    static public UpdateContextElement createUpdateContextElementTemperature() {
+        UpdateContextElement updateContextElement = new UpdateContextElement();
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        updateContextElement.setContextAttributes(Collections.singletonList(contextAttribute));
+        return updateContextElement;
+    }
+
+    static public UpdateContextElementResponse createUpdateContextElementResponseTemperature() {
+        UpdateContextElementResponse updateContextElementResponse = new UpdateContextElementResponse();
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        ContextAttributeResponse contextAttributeResponse = new ContextAttributeResponse();
+        contextAttributeResponse.setContextAttributeList(Collections.singletonList(contextAttribute));
+        contextAttributeResponse.setStatusCode(new StatusCode(CODE_200));
+        updateContextElementResponse.setContextAttributeResponses(Collections.singletonList(contextAttributeResponse));
+        return updateContextElementResponse;
+    }
+
+    static public UpdateContextAttribute createUpdateContextAttributeTemperature() {
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        updateContextAttribute.setAttribute(contextAttribute);
+        return updateContextAttribute;
     }
 
     static public String json(MappingJackson2HttpMessageConverter mapping, Object o) throws IOException {

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/Util.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/Util.java
@@ -221,6 +221,7 @@ public class Util {
 
     static public ContextAttributeResponse createContextAttributeResponseTemperature() {
         ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "DEADBEEF")));
         ContextAttributeResponse contextAttributeResponse = new ContextAttributeResponse();
         contextAttributeResponse.setContextAttributeList(Collections.singletonList(contextAttribute));
         contextAttributeResponse.setStatusCode(new StatusCode(CODE_200));
@@ -253,6 +254,7 @@ public class Util {
     static public UpdateContextAttribute createUpdateContextAttributeTemperature() {
         UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
         ContextAttribute contextAttribute = new ContextAttribute("temp", "float", 15.5);
+        contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "DEADBEEF")));
         updateContextAttribute.setAttribute(contextAttribute);
         return updateContextAttribute;
     }

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/client/NgsiRestClientTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/client/NgsiRestClientTest.java
@@ -19,24 +19,18 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.client.AsyncRestTemplate;
 
 import java.util.function.Consumer;
 
 import static com.orange.ngsi.Util.json;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
 import static org.junit.Assert.*;
 import static com.orange.ngsi.Util.*;

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/client/NgsiRestClientTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/client/NgsiRestClientTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.client;
+
+import com.orange.ngsi.TestConfiguration;
+import com.orange.ngsi.Util;
+import com.orange.ngsi.model.*;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.web.client.AsyncRestTemplate;
+
+import java.util.function.Consumer;
+
+import static com.orange.ngsi.Util.json;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import static org.junit.Assert.*;
+import static com.orange.ngsi.Util.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+/**
+ * Tests for the NgsiRestClient class
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = TestConfiguration.class)
+public class NgsiRestClientTest {
+
+    private static String baseUrl = "http://localhost:8080";
+
+
+    @Autowired
+    @InjectMocks
+    public NgsiRestClient ngsiRestClient;
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter jsonConverter;
+
+    @Autowired
+    private MappingJackson2XmlHttpMessageConverter xmlConverter;
+
+    @Autowired
+    private AsyncRestTemplate asyncRestTemplate;
+
+    private MockRestServiceServer mockServer;
+
+    private Consumer<NotifyContextResponse> onSuccess = Mockito.mock(Consumer.class);
+
+    private Consumer<Throwable> onFailure = Mockito.mock(Consumer.class);
+
+    @Before
+    public void tearUp() {
+        MockitoAnnotations.initMocks(this);
+        this.mockServer = MockRestServiceServer.createServer(asyncRestTemplate);
+        ngsiRestClient.protocolRegistry.registerHost(baseUrl, true); // support JSON
+    }
+
+    @After
+    public void tearDown() {
+        reset(onSuccess);
+        reset(onFailure);
+    }
+
+    @Test
+    public void testAppendContextElement_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createAppendContextElementResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.attributes").isArray())
+                .andExpect(jsonPath("$.attributes[0].name").value("temp"))
+                .andExpect(jsonPath("$.attributes[0].type").value("float"))
+                .andExpect(jsonPath("$.attributes[0].value").value("15.5"))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        AppendContextElementResponse response = ngsiRestClient.appendContextElement(baseUrl, null, "123", Util.createAppendContextElementTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertNull(response.getErrorCode());
+        assertNotNull(response.getContextAttributeResponses());
+        assertEquals(1, response.getContextAttributeResponses().size());
+        assertNotNull(response.getContextAttributeResponses().get(0).getContextAttributeList());
+        assertEquals(1, response.getContextAttributeResponses().get(0).getContextAttributeList().size());
+        assertNotNull(response.getContextAttributeResponses().get(0).getContextAttributeList().get(0));
+        assertEquals("temp", response.getContextAttributeResponses().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextAttributeResponses().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextAttributeResponses().get(0).getContextAttributeList().get(0).getValue());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getContextAttributeResponses().get(0).getStatusCode().getCode());
+    }
+
+    @Test
+    public void testUpdateContextElement_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createUpdateContextElementResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(jsonPath("$.attributes").isArray())
+                .andExpect(jsonPath("$.attributes[0].name").value("temp"))
+                .andExpect(jsonPath("$.attributes[0].type").value("float"))
+                .andExpect(jsonPath("$.attributes[0].value").value("15.5"))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        UpdateContextElementResponse response = ngsiRestClient.updateContextElement(baseUrl, null, "123", Util.createUpdateContextElementTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertNull(response.getErrorCode());
+        assertNotNull(response.getContextAttributeResponses());
+        assertEquals(1, response.getContextAttributeResponses().size());
+        assertNotNull(response.getContextAttributeResponses().get(0).getContextAttributeList());
+        assertEquals(1, response.getContextAttributeResponses().get(0).getContextAttributeList().size());
+        assertNotNull(response.getContextAttributeResponses().get(0).getContextAttributeList().get(0));
+        assertEquals("temp", response.getContextAttributeResponses().get(0).getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextAttributeResponses().get(0).getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextAttributeResponses().get(0).getContextAttributeList().get(0).getValue());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getContextAttributeResponses().get(0).getStatusCode().getCode());
+    }
+
+    @Test
+    public void testGetContextElement_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createContextElementResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        ContextElementResponse response = ngsiRestClient.getContextElement(baseUrl, null, "123").get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response.getContextElement());
+        assertNotNull(response.getContextElement().getContextAttributeList());
+        assertEquals(1, response.getContextElement().getContextAttributeList().size());
+        assertNotNull(response.getContextElement().getContextAttributeList().get(0));
+        assertEquals("temp", response.getContextElement().getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextElement().getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextElement().getContextAttributeList().get(0).getValue());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getStatusCode().getCode());
+    }
+
+    @Test
+    public void testDeleteContextElement_JSON() throws Exception {
+        String responseBody = json(jsonConverter, new StatusCode(CodeEnum.CODE_200));
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        StatusCode response = ngsiRestClient.deleteContextElement(baseUrl, null, "123").get();
+
+        this.mockServer.verify();
+
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getCode());
+    }
+
+    @Test
+    public void testAppendContextAttribute_JSON() throws Exception {
+        String responseBody = json(jsonConverter, new StatusCode(CodeEnum.CODE_200));
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(jsonPath("$.name").value("temp"))
+                .andExpect(jsonPath("$.type").value("float"))
+                .andExpect(jsonPath("$.value").value("15.5"))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        StatusCode response = ngsiRestClient.appendContextAttribute(baseUrl, null, "123", "temp", Util.createUpdateContextAttributeTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getCode());
+    }
+
+    @Test
+    public void testUpdateContextAttribute_JSON() throws Exception {
+        String responseBody = json(jsonConverter, new StatusCode(CodeEnum.CODE_200));
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(jsonPath("$.name").value("temp"))
+                .andExpect(jsonPath("$.type").value("float"))
+                .andExpect(jsonPath("$.value").value("15.5"))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        StatusCode response = ngsiRestClient.updateContextAttribute(baseUrl, null, "123", "temp", Util.createUpdateContextAttributeTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getCode());
+    }
+
+    @Test
+    public void testGetContextAttribute_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createContextAttributeResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        ContextAttributeResponse response = ngsiRestClient.getContextAttribute(baseUrl, null, "123", "temp").get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertNotNull(response.getContextAttributeList());
+        assertEquals(1, response.getContextAttributeList().size());
+        assertNotNull(response.getContextAttributeList().get(0));
+        assertEquals("temp", response.getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextAttributeList().get(0).getValue());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getStatusCode().getCode());
+    }
+
+    @Test
+    public void testDeleteContextAttribute_JSON() throws Exception {
+        String responseBody = json(jsonConverter, new StatusCode(CodeEnum.CODE_200));
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        StatusCode response = ngsiRestClient.deleteContextAttribute(baseUrl, null, "123", "temp").get();
+
+        this.mockServer.verify();
+
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getCode());
+    }
+
+    @Test
+    public void testUpdateContextAttributeValue_JSON() throws Exception {
+        String responseBody = json(jsonConverter, new StatusCode(CodeEnum.CODE_200));
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp/1"))
+                .andExpect(method(HttpMethod.PUT))
+                .andExpect(jsonPath("$.name").value("temp"))
+                .andExpect(jsonPath("$.type").value("float"))
+                .andExpect(jsonPath("$.value").value("15.5"))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        StatusCode response = ngsiRestClient.updateContextAttributeValue(baseUrl, null, "123", "temp", "1", Util.createUpdateContextAttributeTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getCode());
+    }
+
+    @Test
+    public void testGetContextAttributeValue_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createContextAttributeResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp/1"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        ContextAttributeResponse response = ngsiRestClient.getContextAttributeValue(baseUrl, null, "123", "temp", "1").get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertNotNull(response.getContextAttributeList());
+        assertEquals(1, response.getContextAttributeList().size());
+        assertNotNull(response.getContextAttributeList().get(0));
+        assertEquals("temp", response.getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextAttributeList().get(0).getValue());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getStatusCode().getCode());
+    }
+
+    @Test
+    public void testDeleteContextAttributeValue_JSON() throws Exception {
+        String responseBody = json(jsonConverter, new StatusCode(CodeEnum.CODE_200));
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntities/123/attributes/temp/1"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        StatusCode response = ngsiRestClient.deleteContextAttributeValue(baseUrl, null, "123", "temp", "1").get();
+
+        this.mockServer.verify();
+
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getCode());
+    }
+
+    @Test
+    public void testGetContextEntityType_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createQueryContextResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntityTypes/TempSensor"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        QueryContextResponse response = ngsiRestClient.getContextEntityType(baseUrl, null, "TempSensor").get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertNull(response.getErrorCode());
+        assertNotNull(response.getContextElementResponses());
+        assertEquals(1, response.getContextElementResponses().size());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getContextElementResponses().get(0).getStatusCode().getCode());
+        assertNotNull(response.getContextElementResponses().get(0));
+        assertNotNull(response.getContextElementResponses().get(0).getContextElement());
+        assertNotNull(response.getContextElementResponses().get(0).getContextElement().getEntityId());
+        assertEquals("TempSensor", response.getContextElementResponses().get(0).getContextElement().getEntityId().getType());
+        assertNotNull(response.getContextElementResponses().get(0).getContextElement().getContextAttributeList());
+        assertEquals(1, response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().size());
+        assertEquals("temp", response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().get(0).getValue());
+    }
+
+    @Test
+    public void testGetContextEntityTypeAttribute_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createQueryContextResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextEntityTypes/TempSensor/attributes/temp"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        QueryContextResponse response = ngsiRestClient.getContextEntityTypeAttribute(baseUrl, null, "TempSensor", "temp").get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertNull(response.getErrorCode());
+        assertNotNull(response.getContextElementResponses());
+        assertEquals(1, response.getContextElementResponses().size());
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getContextElementResponses().get(0).getStatusCode().getCode());
+        assertNotNull(response.getContextElementResponses().get(0));
+        assertNotNull(response.getContextElementResponses().get(0).getContextElement());
+        assertNotNull(response.getContextElementResponses().get(0).getContextElement().getEntityId());
+        assertEquals("TempSensor", response.getContextElementResponses().get(0).getContextElement().getEntityId().getType());
+        assertNotNull(response.getContextElementResponses().get(0).getContextElement().getContextAttributeList());
+        assertEquals(1, response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().size());
+        assertEquals("temp", response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().get(0).getName());
+        assertEquals("float", response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().get(0).getType());
+        assertEquals("15.5", response.getContextElementResponses().get(0).getContextElement().getContextAttributeList().get(0).getValue());
+    }
+
+    @Test
+    public void testAppendContextSubscription_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createSubscribeContextResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextSubscriptions/"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        SubscribeContextResponse response = ngsiRestClient.appendContextSubscription(baseUrl, null, createSubscribeContextTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertNull(response.getSubscribeError());
+        assertNotNull(response.getSubscribeResponse());
+        assertEquals("12345678", response.getSubscribeResponse().getSubscriptionId());
+        assertEquals("P1M", response.getSubscribeResponse().getDuration());
+    }
+
+    @Test
+    public void testUpdateContextSubscription_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createUpdateContextSubscriptionResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextSubscriptions/12345678"))
+                .andExpect(method(HttpMethod.PUT))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        UpdateContextSubscriptionResponse response = ngsiRestClient.updateContextSubscription(baseUrl, null, "12345678", createUpdateContextSubscriptionTemperature()).get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertNull(response.getSubscribeError());
+        assertNotNull(response.getSubscribeResponse());
+        assertEquals("12345678", response.getSubscribeResponse().getSubscriptionId());
+        assertEquals("P1M", response.getSubscribeResponse().getDuration());
+    }
+
+    @Test
+    public void testDeleteContextSubscription_JSON() throws Exception {
+        String responseBody = json(jsonConverter, createUnsubscribeContextSubscriptionResponseTemperature());
+
+        mockServer.expect(requestTo(baseUrl+"/ngsi10/contextSubscriptions/12345678"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        UnsubscribeContextResponse response = ngsiRestClient.deleteContextSubscription(baseUrl, null, "12345678").get();
+
+        this.mockServer.verify();
+
+        assertNotNull(response);
+        assertEquals(CodeEnum.CODE_200.getLabel(), response.getStatusCode().getCode());
+        assertEquals("12345678", response.getSubscriptionId());
+    }
+}

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeControllerHelper.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.ngsi.server;
 
 import com.orange.ngsi.model.*;

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRESTControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRESTControllerHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.server;
+
+import com.orange.ngsi.Util;
+import com.orange.ngsi.model.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/rest/i")
+public class FakeRESTControllerHelper extends NgsiRESTBaseController {
+
+    @Override
+    protected AppendContextElementResponse appendContextElement(String entityID, AppendContextElement appendContextElement) throws Exception {
+        return Util.createAppendContextElementResponseTemperature();
+    }
+
+    @Override
+    protected UpdateContextElementResponse updateContextElement(String entityID, UpdateContextElement updateContextElement) throws Exception {
+        return Util.createUpdateContextElementResponseTemperature();
+    }
+
+    @Override
+    protected ContextElementResponse getContextElement(String entityID) throws Exception {
+        return Util.createUpdateContextElement();
+    }
+
+    @Override
+    protected StatusCode deleteContextElement(String entityID) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected StatusCode appendContextAttribute(String entityID, String attributeName, UpdateContextAttribute updateContextAttribute) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected StatusCode updateContextAttribute(String entityID, String attributeName, Optional<String> valueID, UpdateContextAttribute updateContextElementRequest) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName, Optional<String> valueID) throws Exception {
+        return Util.createContextAttributeResponseTemperature();
+    }
+
+    @Override
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName, Optional<String> valueID) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected QueryContextResponse getContextEntitiesType(String typeName, Optional<String> attributeName) throws Exception {
+        return Util.createQueryContextResponseTemperature();
+    }
+
+    @Override
+    protected SubscribeContextResponse createSubscription(SubscribeContext subscribeContext) throws Exception {
+        return Util.createSubscribeContextResponseTemperature();
+    }
+
+    @Override
+    protected UpdateContextSubscriptionResponse updateSubscription(UpdateContextSubscription updateContextSubscription) throws Exception {
+        return Util.createUpdateContextSubscriptionResponseTemperature();
+    }
+
+    @Override
+    protected UnsubscribeContextResponse deleteSubscription(String subscriptionID) throws Exception {
+        return Util.createUnsubscribeContextSubscriptionResponseTemperature();
+    }
+}

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRESTControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRESTControllerHelper.java
@@ -32,7 +32,7 @@ public class FakeRESTControllerHelper extends NgsiRESTBaseController {
 
     @Override
     protected ContextElementResponse getContextElement(String entityID) throws Exception {
-        return Util.createUpdateContextElement();
+        return Util.createContextElementResponseTemperature();
     }
 
     @Override

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRestControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRestControllerHelper.java
@@ -50,17 +50,7 @@ public class FakeRestControllerHelper extends NgsiRestBaseController {
     }
 
     @Override
-    protected StatusCode updateContextAttribute(String entityID, String attributeName, String valueID, UpdateContextAttribute updateContextElementRequest) throws Exception {
-        return new StatusCode(CodeEnum.CODE_200);
-    }
-
-    @Override
     protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName) throws Exception {
-        return Util.createContextAttributeResponseTemperature();
-    }
-
-    @Override
-    protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName, String valueID) throws Exception {
         return Util.createContextAttributeResponseTemperature();
     }
 
@@ -70,7 +60,17 @@ public class FakeRestControllerHelper extends NgsiRestBaseController {
     }
 
     @Override
-    protected StatusCode deleteContextAttribute(String entityID, String attributeName, String valueID) throws Exception {
+    protected StatusCode updateContextAttributeValue(String entityID, String attributeName, String valueID, UpdateContextAttribute updateContextElementRequest) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected ContextAttributeResponse getContextAttributeValue(String entityID, String attributeName, String valueID) throws Exception {
+        return Util.createContextAttributeResponseTemperature();
+    }
+
+    @Override
+    protected StatusCode deleteContextAttributeValue(String entityID, String attributeName, String valueID) throws Exception {
         return new StatusCode(CodeEnum.CODE_200);
     }
 

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRestControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRestControllerHelper.java
@@ -45,22 +45,42 @@ public class FakeRestControllerHelper extends NgsiRestBaseController {
     }
 
     @Override
-    protected StatusCode updateContextAttribute(String entityID, String attributeName, Optional<String> valueID, UpdateContextAttribute updateContextElementRequest) throws Exception {
+    protected StatusCode updateContextAttribute(String entityID, String attributeName, UpdateContextAttribute updateContextElementRequest) throws Exception {
         return new StatusCode(CodeEnum.CODE_200);
     }
 
     @Override
-    protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName, Optional<String> valueID) throws Exception {
+    protected StatusCode updateContextAttribute(String entityID, String attributeName, String valueID, UpdateContextAttribute updateContextElementRequest) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName) throws Exception {
         return Util.createContextAttributeResponseTemperature();
     }
 
     @Override
-    protected StatusCode deleteContextAttribute(String entityID, String attributeName, Optional<String> valueID) throws Exception {
+    protected ContextAttributeResponse getContextAttribute(String entityID, String attributeName, String valueID) throws Exception {
+        return Util.createContextAttributeResponseTemperature();
+    }
+
+    @Override
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName) throws Exception {
         return new StatusCode(CodeEnum.CODE_200);
     }
 
     @Override
-    protected QueryContextResponse getContextEntitiesType(String typeName, Optional<String> attributeName) throws Exception {
+    protected StatusCode deleteContextAttribute(String entityID, String attributeName, String valueID) throws Exception {
+        return new StatusCode(CodeEnum.CODE_200);
+    }
+
+    @Override
+    protected QueryContextResponse getContextEntitiesType(String typeName) throws Exception {
+        return Util.createQueryContextResponseTemperature();
+    }
+
+    @Override
+    protected QueryContextResponse getContextEntitiesType(String typeName, String attributeName) throws Exception {
         return Util.createQueryContextResponseTemperature();
     }
 

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRestControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/FakeRestControllerHelper.java
@@ -13,12 +13,11 @@ import com.orange.ngsi.model.*;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collections;
 import java.util.Optional;
 
 @RestController
 @RequestMapping("/rest/i")
-public class FakeRESTControllerHelper extends NgsiRESTBaseController {
+public class FakeRestControllerHelper extends NgsiRestBaseController {
 
     @Override
     protected AppendContextElementResponse appendContextElement(String entityID, AppendContextElement appendContextElement) throws Exception {

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiBaseControllerTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiBaseControllerTest.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2015 Orange
  *

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiRESTBaseControllerTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiRESTBaseControllerTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2016 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
+package com.orange.ngsi.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.orange.ngsi.TestConfiguration;
+import com.orange.ngsi.model.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.context.WebApplicationContext;
+
+import static com.orange.ngsi.Util.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+/**
+ * Tests for the NGSI REST base controller.
+ * This class uses the two NotImplementedRESTControllerHelper and FakeRESTControllerHelper classes
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = TestConfiguration.class)
+@WebAppConfiguration
+public class NgsiRESTBaseControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private MappingJackson2HttpMessageConverter jsonConverter;
+
+    private ObjectMapper xmlmapper = new XmlMapper();
+
+    @Before
+    public void setup() throws Exception {
+        this.mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    public void checkAppendContextElementNotImplemented() throws Exception {
+        mockMvc.perform(
+                post("/rest/ni/contextEntities/test").content(json(jsonConverter, createAppendContextElementTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkUpdateContextElementNotImplemented() throws Exception {
+        mockMvc.perform(
+                put("/rest/ni/contextEntities/test").content(json(jsonConverter, createUpdateContextElementTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkGetContextElementNotImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/ni/contextEntities/test").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkDeleteContextElementNotImplemented() throws Exception {
+        mockMvc.perform(
+                delete("/rest/ni/contextEntities/test").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkAppendContextAttributeNotImplemented() throws Exception {
+        mockMvc.perform(
+                post("/rest/ni/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkUpdateContextAttributeNotImplemented() throws Exception {
+        mockMvc.perform(
+                put("/rest/ni/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkGetContextAttributeNotImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/ni/contextEntities/test/attributes/a").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkDeleteContextAttributeNotImplemented() throws Exception {
+        mockMvc.perform(
+                delete("/rest/ni/contextEntities/test/attributes/a").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkGetContextEntitiesTypeNotImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/ni/contextEntityTypes/test").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkGetContextEntitiesTypeAttributesNotImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/ni/contextEntityTypes/test/attributes/a").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkAddSubscriptionNotImplemented() throws Exception {
+        mockMvc.perform(
+                post("/rest/ni/contextSubscriptions")
+                        .content(json(jsonConverter, createSubscribeContextTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkUpdateSubscriptionNotImplemented() throws Exception {
+        mockMvc.perform(
+                put("/rest/ni/contextSubscriptions/12345678")
+                        .content(json(jsonConverter, createUpdateContextSubscriptionTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void checkDeleteSubscriptionNotImplemented() throws Exception {
+        mockMvc.perform(
+                delete("/rest/ni/contextSubscriptions/23")
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
+    }
+
+    @Test
+    public void jsonSyntaxErrorHandling() throws Exception {
+
+        mockMvc.perform(post("/rest/ni/contextEntities/test").content("bad JSON").contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_400.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.reasonPhrase").value(CodeEnum.CODE_400.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.details").value(CodeEnum.CODE_400.getLongPhrase()));
+    }
+
+    @Test
+    public void xmlSyntaxErrorHandling() throws Exception {
+
+        mockMvc.perform(post("/rest/ni/contextEntities/test").content("bad xml").contentType(MediaType.APPLICATION_XML).header("Host", "localhost").accept(MediaType.APPLICATION_XML))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.xpath("statusCode/code").string(CodeEnum.CODE_400.getLabel()))
+                .andExpect(MockMvcResultMatchers.xpath("statusCode/reasonPhrase").string(CodeEnum.CODE_400.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.xpath("statusCode/details").string(CodeEnum.CODE_400.getLongPhrase()));
+    }
+
+    @Test
+    public void checkUpdateSubscriptionMistmatchId() throws Exception {
+        mockMvc.perform(
+                put("/rest/ni/contextSubscriptions/87654321")
+                        .content(json(jsonConverter, createUpdateContextSubscriptionTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_472.getLabel()));
+    }
+
+    @Test
+    public void checkAppendContextElementImplemented() throws Exception {
+        mockMvc.perform(
+                post("/rest/i/contextEntities/test").content(json(jsonConverter, createAppendContextElementTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes[0].name").value("temp"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes[0].type").value("float"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes[0].value").value("15.5"));
+    }
+
+    @Test
+    public void checkUpdateContextElementImplemented() throws Exception {
+        mockMvc.perform(put("/rest/i/contextEntities/test").content(json(jsonConverter, createUpdateContextElementTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes[0].name").value("temp"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes[0].type").value("float"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].attributes[0].value").value("15.5"));
+    }
+
+    @Test
+    public void checkGetContextElementImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/i/contextEntities/test").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextElement.attributes").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextElement.attributes[0].name").value("temp"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextElement.attributes[0].type").value("float"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextElement.attributes[0].value").value("15.5"));
+    }
+
+    @Test
+    public void checkDeleteContextElementImplemented() throws Exception {
+        mockMvc.perform(
+                delete("/rest/i/contextEntities/test").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+    }
+
+    @Test
+    public void checkAppendContextAttributeImplemented() throws Exception {
+        mockMvc.perform(
+                post("/rest/i/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+    }
+
+    @Test
+    public void checkUpdateContextAttributeImplemented() throws Exception {
+        mockMvc.perform(
+                put("/rest/i/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+    }
+
+    @Test
+    public void checkGetContextAttributeImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/i/contextEntities/test/attributes/a").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attributes").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].name").value("temp"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].type").value("float"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].value").value("15.5"));    }
+
+    @Test
+    public void checkDeleteContextAttributeImplemented() throws Exception {
+        mockMvc.perform(
+                delete("/rest/i/contextEntities/test/attributes/a").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
+    }
+
+    @Test
+    public void checkGetContextEntitiesTypeImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/i/contextEntityTypes/test").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.id").value("S1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.type").value("TempSensor"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.isPattern").value("false"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes[0].name").value("temp"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes[0].type").value("float"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes[0].value").value("15.5"));
+    }
+
+    @Test
+    public void checkGetContextEntitiesTypeAttributeImplemented() throws Exception {
+        mockMvc.perform(
+                get("/rest/i/contextEntityTypes/test/attributes/temp").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.id").value("S1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.type").value("TempSensor"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.isPattern").value("false"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes[0].name").value("temp"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes[0].type").value("float"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contextResponses[0].contextElement.attributes[0].value").value("15.5"));
+    }
+
+    @Test
+    public void checkAddSubscriptionImplemented() throws Exception {
+        mockMvc.perform(
+                post("/rest/i/contextSubscriptions")
+                        .content(json(jsonConverter, createSubscribeContextTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.subscribeResponse.subscriptionId").value("12345678"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.subscribeResponse.duration").value("P1M"));
+    }
+
+    @Test
+    public void checkUpdateSubscriptionImplemented() throws Exception {
+        mockMvc.perform(
+                put("/rest/i/contextSubscriptions/12345678")
+                        .content(json(jsonConverter, createUpdateContextSubscriptionTemperature())).contentType(MediaType.APPLICATION_JSON)
+                        .header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.subscribeResponse.subscriptionId").value("12345678"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.subscribeResponse.duration").value("P1M"));    }
+
+    @Test
+    public void checkDeleteSubscriptionImplemented() throws Exception {
+        mockMvc.perform(
+                delete("/rest/i/contextSubscriptions/23").header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.code").value(CodeEnum.CODE_200.getLabel()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.reasonPhrase").value(CodeEnum.CODE_200.getShortPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode.details").value(CodeEnum.CODE_200.getLongPhrase()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.subscriptionId").value("12345678"));
+    }
+}
+

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiRestBaseControllerTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiRestBaseControllerTest.java
@@ -32,12 +32,12 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 
 /**
  * Tests for the NGSI REST base controller.
- * This class uses the two NotImplementedRESTControllerHelper and FakeRESTControllerHelper classes
+ * This class uses the two NotImplementedRestControllerHelper and FakeRestControllerHelper classes
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = TestConfiguration.class)
 @WebAppConfiguration
-public class NgsiRESTBaseControllerTest {
+public class NgsiRestBaseControllerTest {
 
     private MockMvc mockMvc;
 

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiRestBaseControllerTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiRestBaseControllerTest.java
@@ -89,7 +89,7 @@ public class NgsiRestBaseControllerTest {
     @Test
     public void checkAppendContextAttributeNotImplemented() throws Exception {
         mockMvc.perform(
-                post("/rest/ni/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                post("/rest/ni/contextEntities/test/attributes/temp").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
     }
@@ -97,7 +97,7 @@ public class NgsiRestBaseControllerTest {
     @Test
     public void checkUpdateContextAttributeNotImplemented() throws Exception {
         mockMvc.perform(
-                put("/rest/ni/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                put("/rest/ni/contextEntities/test/attributes/temp").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_403.getLabel()));
     }
@@ -247,7 +247,7 @@ public class NgsiRestBaseControllerTest {
     @Test
     public void checkAppendContextAttributeImplemented() throws Exception {
         mockMvc.perform(
-                post("/rest/i/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                post("/rest/i/contextEntities/test/attributes/temp").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
     }
@@ -255,7 +255,7 @@ public class NgsiRestBaseControllerTest {
     @Test
     public void checkUpdateContextAttributeImplemented() throws Exception {
         mockMvc.perform(
-                put("/rest/i/contextEntities/test/attributes/a").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
+                put("/rest/i/contextEntities/test/attributes/temp").content(json(jsonConverter, createUpdateContextAttributeTemperature())).contentType(MediaType.APPLICATION_JSON).header("Host", "localhost").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(CodeEnum.CODE_200.getLabel()));
     }
@@ -271,7 +271,8 @@ public class NgsiRestBaseControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.attributes").isArray())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].name").value("temp"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].type").value("float"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].value").value("15.5"));    }
+                .andExpect(MockMvcResultMatchers.jsonPath("$.attributes[0].value").value("15.5"));
+    }
 
     @Test
     public void checkDeleteContextAttributeImplemented() throws Exception {

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiValidationTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiValidationTest.java
@@ -641,7 +641,7 @@ public class NgsiValidationTest {
     public void testUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
         updateContextAttribute.setAttribute(new ContextAttribute("temp", "float", "15.5"));
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", null, updateContextAttribute);
     }
 
 
@@ -651,49 +651,49 @@ public class NgsiValidationTest {
         contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "DEADBEEF")));
         UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
         updateContextAttribute.setAttribute(contextAttribute);
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", "DEADBEEF", updateContextAttribute);
     }
 
     @Test
     public void nullEntityIDInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("entityID");
-        ngsiValidation.checkUpdateContextAttribute(null, "temp", Optional.empty(), new UpdateContextAttribute());
+        ngsiValidation.checkUpdateContextAttribute(null, "temp", null, new UpdateContextAttribute());
     }
 
     @Test
     public void emptyEntityIDInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("entityID");
-        ngsiValidation.checkUpdateContextAttribute("", "temp", Optional.empty(), new UpdateContextAttribute());
+        ngsiValidation.checkUpdateContextAttribute("", "temp", null, new UpdateContextAttribute());
     }
 
     @Test
     public void nullAttributeNameInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("attributeName");
-        ngsiValidation.checkUpdateContextAttribute("12345678", null, Optional.empty(), new UpdateContextAttribute());
+        ngsiValidation.checkUpdateContextAttribute("12345678", null, null, new UpdateContextAttribute());
     }
 
     @Test
     public void emptyAttributeNameInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("attributeName");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "", Optional.empty(), new UpdateContextAttribute());
+        ngsiValidation.checkUpdateContextAttribute("12345678", "", null, new UpdateContextAttribute());
     }
 
     @Test
     public void nullUpdateContextAttributeInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("attribute");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), null);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", null, null);
     }
 
     @Test
     public void nullContextAttributeInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("attribute");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), new UpdateContextAttribute());
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", null, new UpdateContextAttribute());
     }
 
     @Test
@@ -703,7 +703,7 @@ public class NgsiValidationTest {
         updateContextAttribute.setAttribute(contextAttribute);
         thrown.expect(MismatchIdException.class);
         thrown.expectMessage("BADATTR");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", null, updateContextAttribute);
     }
 
     @Test
@@ -713,7 +713,7 @@ public class NgsiValidationTest {
         updateContextAttribute.setAttribute(contextAttribute);
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("Metadata ID");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", "DEADBEEF", updateContextAttribute);
     }
 
     @Test
@@ -724,7 +724,7 @@ public class NgsiValidationTest {
         updateContextAttribute.setAttribute(contextAttribute);
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("Metadata ID");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", "DEADBEEF", updateContextAttribute);
     }
 
     @Test
@@ -735,7 +735,7 @@ public class NgsiValidationTest {
         updateContextAttribute.setAttribute(contextAttribute);
         thrown.expect(MismatchIdException.class);
         thrown.expectMessage("DEADBEEF");
-        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", "DEADBEEF", updateContextAttribute);
     }
 
     @Test

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiValidationTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiValidationTest.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.orange.ngsi.model.CodeEnum.CODE_200;
 
@@ -634,6 +635,107 @@ public class NgsiValidationTest {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("contextAttributes");
         ngsiValidation.checkUpdateContextElement(updateContextElement);
+    }
+
+    @Test
+    public void testUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(new ContextAttribute("temp", "float", "15.5"));
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), updateContextAttribute);
+    }
+
+
+    @Test
+    public void testUpdateContextAttributeWithValueID() throws MissingRequestParameterException, MismatchIdException {
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", "15.5");
+        contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "DEADBEEF")));
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(contextAttribute);
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+    }
+
+    @Test
+    public void nullEntityIDInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("entityID");
+        ngsiValidation.checkUpdateContextAttribute(null, "temp", Optional.empty(), new UpdateContextAttribute());
+    }
+
+    @Test
+    public void emptyEntityIDInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("entityID");
+        ngsiValidation.checkUpdateContextAttribute("", "temp", Optional.empty(), new UpdateContextAttribute());
+    }
+
+    @Test
+    public void nullAttributeNameInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("attributeName");
+        ngsiValidation.checkUpdateContextAttribute("12345678", null, Optional.empty(), new UpdateContextAttribute());
+    }
+
+    @Test
+    public void emptyAttributeNameInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("attributeName");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "", Optional.empty(), new UpdateContextAttribute());
+    }
+
+    @Test
+    public void nullUpdateContextAttributeInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("attribute");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), null);
+    }
+
+    @Test
+    public void nullContextAttributeInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("attribute");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), new UpdateContextAttribute());
+    }
+
+    @Test
+    public void attributeNameMismatchInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        ContextAttribute contextAttribute = new ContextAttribute("BADATTR", "float", "15.5");
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(contextAttribute);
+        thrown.expect(MismatchIdException.class);
+        thrown.expectMessage("BADATTR");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.empty(), updateContextAttribute);
+    }
+
+    @Test
+    public void nullMetadataInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", "15.5");
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(contextAttribute);
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("Metadata ID");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+    }
+
+    @Test
+    public void emptyMetadataInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", "15.5");
+        contextAttribute.setMetadata(Collections.emptyList());
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(contextAttribute);
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("Metadata ID");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
+    }
+
+    @Test
+    public void mismatchMetadataIDInUpdateContextAttribute() throws MissingRequestParameterException, MismatchIdException {
+        ContextAttribute contextAttribute = new ContextAttribute("temp", "float", "15.5");
+        contextAttribute.setMetadata(Collections.singletonList(new ContextMetadata("ID", "string", "CAFEBABE")));
+        UpdateContextAttribute updateContextAttribute = new UpdateContextAttribute();
+        updateContextAttribute.setAttribute(contextAttribute);
+        thrown.expect(MismatchIdException.class);
+        thrown.expectMessage("DEADBEEF");
+        ngsiValidation.checkUpdateContextAttribute("12345678", "temp", Optional.of("DEADBEEF"), updateContextAttribute);
     }
 
     @Test

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiValidationTest.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NgsiValidationTest.java
@@ -8,7 +8,9 @@
 
 package com.orange.ngsi.server;
 
+import com.orange.ngsi.exception.MismatchIdException;
 import com.orange.ngsi.exception.MissingRequestParameterException;
+import com.orange.ngsi.exception.UnsupportedOperationException;
 import com.orange.ngsi.model.*;
 import org.junit.Rule;
 import org.junit.Test;
@@ -598,5 +600,49 @@ public class NgsiValidationTest {
         thrown.expect(MissingRequestParameterException.class);
         thrown.expectMessage("attributeExpression");
         ngsiValidation.checkQueryContext(queryContext);
+    }
+
+    @Test
+    public void nullAttributesInAppendContextElement() throws MissingRequestParameterException {
+        AppendContextElement appendContextElement = new AppendContextElement();
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("contextAttributes");
+        ngsiValidation.checkAppendContextElement(appendContextElement);
+    }
+
+    @Test
+    public void emptyAttributesInAppendContextElement() throws MissingRequestParameterException {
+        AppendContextElement appendContextElement = new AppendContextElement();
+        appendContextElement.setAttributeList(Collections.emptyList());
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("contextAttributes");
+        ngsiValidation.checkAppendContextElement(appendContextElement);
+    }
+
+    @Test
+    public void nullAttributesInUpdateContextElement() throws MissingRequestParameterException {
+        UpdateContextElement updateContextElement = new UpdateContextElement();
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("contextAttributes");
+        ngsiValidation.checkUpdateContextElement(updateContextElement);
+    }
+
+    @Test
+    public void emptyAttributesInUpdateContextElement() throws MissingRequestParameterException {
+        UpdateContextElement updateContextElement = new UpdateContextElement();
+        updateContextElement.setContextAttributes(Collections.emptyList());
+        thrown.expect(MissingRequestParameterException.class);
+        thrown.expectMessage("contextAttributes");
+        ngsiValidation.checkUpdateContextElement(updateContextElement);
+    }
+
+    @Test
+    public void differentSubscriptionIDInUpdateSubscription() throws Exception {
+        UpdateContextSubscription updateContextSubscription = new UpdateContextSubscription();
+        EntityId entityId = new EntityId("Room1","Room",false);
+        updateContextSubscription.setSubscriptionId("12345");
+        thrown.expect(MismatchIdException.class);
+        thrown.expectMessage("mismatch id between parameter 54321 and body 12345");
+        ngsiValidation.checkUpdateSubscription("54321", updateContextSubscription);
     }
 }

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NotImplementedRESTControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NotImplementedRESTControllerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Orange
+ * Copyright (C) 2016 Orange
  *
  * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
  * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/ni")
-public class NotImplementedControllerHelper extends NgsiBaseController {
+@RequestMapping("/rest/ni")
+public class NotImplementedRESTControllerHelper extends NgsiRESTBaseController {
 
 }

--- a/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NotImplementedRestControllerHelper.java
+++ b/cepheus-ngsi/src/test/java/com/orange/ngsi/server/NotImplementedRestControllerHelper.java
@@ -13,6 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/ni")
-public class NotImplementedRESTControllerHelper extends NgsiRESTBaseController {
+public class NotImplementedRestControllerHelper extends NgsiRestBaseController {
 
 }

--- a/doc/broker/index.md
+++ b/doc/broker/index.md
@@ -50,7 +50,8 @@ The subscriptions are persisted in a Sqlite database.
 
 The broker has many limitations due to its simple design compared to a complete broker implementation.
 
-- Broker only supports `registerContext`, `updateContext`, `queryContext`, `subscribeContext`, `unsubscribeContext` and `notifyContext` operations from NGSI v1 API (json formated).
+- Broker supports all NGGSI-10 standard and convenient operations from the NGSI v1 API except for the 'updateContextSubscriptions' operation.
+- Broker only support the  NGSI-9 `registerContext` operation from the NGSI v1 API for request forwarding.
 - Subscriptions only support `ONCHANGE` as type of notification of `notifyCondition`.
 - Subscriptions do not supportt `throttling`, `restriction` or `condValues`.
 - If multiple NGSI providers register the same Context Entities, only the first provider will get the forwarded `queryContext` or `updateContext` requests.


### PR DESCRIPTION
Add support for NGSI 10 convenient REST operations to the Broker.

The goal is to support a REST interface to access to Fiware data though the broker.

This adds the following endpoints:
 - `POST/PUT/GET/DELETE /v1/contextEntities/{entityID}`
 - `POST/PUT/GET/DELETE /v1/contextEntities/{entityID}/attributes/{attributeName}`
 - `PUT/GET/DELETE /v1/contextEntities/{entityID}/attributes/{attributeName}/{valueID}`
 - `GET /v1/contextEntityType/{typeName}`
 - `GET /v1/contextEntityType/{typeName}/attributes/{attributeName}`
 - `POST /v1/contextSubscriptions`
 - `GET/DELETE /v1/contextSubscriptions/{subscriptionID}`

All these NGSI-10 REST "convenient" operations are supported on the Broker and mapped back internally to the standard operations (`/updateContext`, `/queryContext`, etc...).

Original intention was to support JSON-LD on a RESTfull NGSIv1 interface.
This goal has since been dropped and will come with with NGSIv2 support.
