### PR TITLE
cep: clean subscription

### DIFF
--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/SubscriptionManager.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/SubscriptionManager.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.http.HttpHeaders;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
@@ -135,24 +136,27 @@ public class SubscriptionManager {
 
     /**
      * Check that a given subscription is valid
+     * unsubscribe if is invalid
      *
      * @param subscriptionId the id of subscription
      * @return true if subscription is valid
      */
-    public boolean isSubscriptionValid(String subscriptionId) {
+    public boolean validateSubscriptionId(String subscriptionId, String originatorUrl) {
         if (validateSubscriptionsId) {
-            return subscriptions.isSubscriptionValid(subscriptionId);
+            boolean isValid = subscriptions.isSubscriptionValid(subscriptionId);
+            if (!isValid) {
+                logger.warn("unsubscribeContext request: clean invalid subscription id {} / {}", subscriptionId, originatorUrl);
+                //TODO: add support multi-tenant subscription
+                ngsiClient.unsubscribeContext(originatorUrl, null, subscriptionId).addCallback(
+                        unsubscribeContextResponse ->
+                                logger.debug("unsubscribeContext completed for {}", originatorUrl),
+                        throwable ->
+                                logger.warn("unsubscribeContext failed for {}: {}", originatorUrl, throwable.toString())
+                );
+            }
+            return isValid;
         }
         return true;
-    }
-
-    /**
-     * get the value of the validateSubscriptionsId
-     *
-     * @return the value of validateSubscriptionsId
-     */
-    public boolean validateSubscriptionsId() {
-        return validateSubscriptionsId;
     }
 
     @PreDestroy

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/SubscriptionManager.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/SubscriptionManager.java
@@ -146,6 +146,15 @@ public class SubscriptionManager {
         return true;
     }
 
+    /**
+     * get the value of the validateSubscriptionsId
+     *
+     * @return the value of validateSubscriptionsId
+     */
+    public boolean validateSubscriptionsId() {
+        return validateSubscriptionsId;
+    }
+
     @PreDestroy
     public void shutdownGracefully() {
 

--- a/cepheus-cep/src/test/java/com/orange/cepheus/cep/SubscriptionManagerTest.java
+++ b/cepheus-cep/src/test/java/com/orange/cepheus/cep/SubscriptionManagerTest.java
@@ -186,6 +186,11 @@ public class SubscriptionManagerTest {
 
     }
 
+    @Test
+    public void testValidateSubscriptionsId() {
+        Assert.isTrue(subscriptionManager.validateSubscriptionsId());
+    }
+
     private  void callSuccessCallback (ArgumentCaptor<SuccessCallback> successArg) {
         SubscribeContextResponse response = new SubscribeContextResponse();
         SubscribeResponse subscribeResponse = new SubscribeResponse();

--- a/cepheus-cep/src/test/java/com/orange/cepheus/cep/SubscriptionManagerTest.java
+++ b/cepheus-cep/src/test/java/com/orange/cepheus/cep/SubscriptionManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -187,8 +188,43 @@ public class SubscriptionManagerTest {
     }
 
     @Test
-    public void testValidateSubscriptionsId() {
-        Assert.isTrue(subscriptionManager.validateSubscriptionsId());
+    public void testInvalideSubscription() {
+        // Mock future for unsubscribeContext
+        ListenableFuture<UnsubscribeContextResponse> responseFuture = Mockito.mock(ListenableFuture.class);
+        doNothing().when(responseFuture).addCallback(any(), any());
+        when(ngsiClient.unsubscribeContext(eq("http://iotAgent"), eq(null), eq("9999"))).thenReturn(responseFuture);
+        subscriptionManager.validateSubscriptionId("9999", "http://iotAgent");
+    }
+
+    @Test
+    public void testValideSubscription() {
+        // add configuration
+        // Mock the task scheduler and capture the runnable
+        ArgumentCaptor<Runnable> runnableArg = ArgumentCaptor.forClass(Runnable.class);
+        when(taskScheduler.scheduleWithFixedDelay(runnableArg.capture(), anyLong())).thenReturn(Mockito.mock(ScheduledFuture.class));
+
+        // Mock the response to the subsribeContext
+        ArgumentCaptor<SuccessCallback> successArg = ArgumentCaptor.forClass(SuccessCallback.class);
+        ListenableFuture<SubscribeContextResponse> responseFuture = Mockito.mock(ListenableFuture.class);
+        doNothing().when(responseFuture).addCallback(successArg.capture(), any());
+
+        Configuration configuration = getBasicConf();
+        subscriptionManager.setConfiguration(configuration);
+
+        // Capture the arg of subscription and return the mocked future
+        ArgumentCaptor<String> urlProviderArg = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<SubscribeContext> subscribeContextArg = ArgumentCaptor.forClass(SubscribeContext.class);
+        when(ngsiClient.subscribeContext(urlProviderArg.capture(), eq(null), subscribeContextArg.capture())).thenReturn(responseFuture);
+
+        // Execute scheduled runnable
+        runnableArg.getValue().run();
+
+        // Return the SubscribeContextResponse
+        callSuccessCallback(successArg);
+
+        // check ngsiClient.unsubscribe() is never called
+        verify(ngsiClient, never()).unsubscribeContext(any(), any(), any());
+        subscriptionManager.validateSubscriptionId("12345678", "http://iotAgent");
     }
 
     private  void callSuccessCallback (ArgumentCaptor<SuccessCallback> successArg) {

--- a/cepheus-cep/src/test/java/com/orange/cepheus/cep/controller/NgsiControllerMultiTenantTest.java
+++ b/cepheus-cep/src/test/java/com/orange/cepheus/cep/controller/NgsiControllerMultiTenantTest.java
@@ -102,7 +102,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContext() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(true);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(true);
         when(eventMapper.eventFromContextElement(any())).thenReturn(event);
         doNothing().when(complexEventProcessor).processEvent(any());
         NotifyContext notifyContext = createNotifyContextTempSensor(0);
@@ -116,7 +116,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContextWithTypeNotFoundException() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(true);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(true);
         doThrow(TypeNotFoundException.class).when(eventMapper).eventFromContextElement(any());
 
         NotifyContext notifyContext = createNotifyContextTempSensor(0);
@@ -134,7 +134,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContextWithEventProcessingException() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(true);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(true);
         doThrow(EventProcessingException.class).when(eventMapper).eventFromContextElement(any());
 
         NotifyContext notifyContext = createNotifyContextTempSensor(0);
@@ -151,7 +151,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContextWithInvalidateSubscriptionId() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(false);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(false);
 
         NotifyContext notifyContext = createNotifyContextTempSensor(0);
 
@@ -169,7 +169,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContextWithBadServicePath() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(true);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(true);
         NotifyContext notifyContext = createNotifyContextTempSensor(0);
 
         mockMvc.perform(post("/v1/notifyContext")
@@ -185,7 +185,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContextBadService() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(true);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(true);
         NotifyContext notifyContext = createNotifyContextTempSensor(0);
 
         mockMvc.perform(post("/v1/notifyContext")
@@ -201,7 +201,7 @@ public class NgsiControllerMultiTenantTest {
     @Test
     public void postNotifyContextWithTenant() throws Exception {
 
-        when(subscriptionManager.isSubscriptionValid(any())).thenReturn(true);
+        when(subscriptionManager.validateSubscriptionId(any(), any())).thenReturn(true);
         Configuration configuration = getBasicConf();
         mockMvc.perform(post("/v1/admin/config")
                 .header("Fiware-Service", "smartcity")


### PR DESCRIPTION
Fixes issue #40 

The CEP subscribes to the Broker entities configured in the configuration file.
The CEP does not persist subscriptions.
If the CEP is restarted (after a crash or a user stop), the CEP done again the subscriptions.
The broker sends two notifications (during 1H of subscription time), and one of them is invalid and therefore rejected.

It is proposed to reject the notification but also to send the Broker an unregistration so the Broker could clean the subscription. The Broker will send a single notification.

The unsubscribe will be made only if the subscription is invalid and if the susbcription third mechanism is not engaged.