### PR TITLE
fix: add licenses headers

### DIFF
--- a/doc/examples/mocks/mock-iotagent/src/main/java/com/orange/cepheus/mockiotagent/AdminController.java
+++ b/doc/examples/mocks/mock-iotagent/src/main/java/com/orange/cepheus/mockiotagent/AdminController.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockiotagent;
 
 import com.orange.ngsi.client.NgsiClient;

--- a/doc/examples/mocks/mock-iotagent/src/main/java/com/orange/cepheus/mockiotagent/Application.java
+++ b/doc/examples/mocks/mock-iotagent/src/main/java/com/orange/cepheus/mockiotagent/Application.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockiotagent;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/doc/examples/mocks/mock-iotagent/src/main/java/com/orange/cepheus/mockiotagent/NgsiController.java
+++ b/doc/examples/mocks/mock-iotagent/src/main/java/com/orange/cepheus/mockiotagent/NgsiController.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockiotagent;
 
 import com.orange.ngsi.model.*;

--- a/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/AdminController.java
+++ b/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/AdminController.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockorion;
 
 import com.orange.cepheus.mockorion.model.Query;

--- a/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/Application.java
+++ b/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/Application.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockorion;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/NgsiController.java
+++ b/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/NgsiController.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockorion;
 
 import com.orange.ngsi.model.*;

--- a/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/model/Query.java
+++ b/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/model/Query.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockorion.model;
 
 import org.hibernate.validator.constraints.NotEmpty;

--- a/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/model/Update.java
+++ b/doc/examples/mocks/mock-orion/src/main/java/com/orange/cepheus/mockorion/model/Update.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2015 Orange
+ *
+ * This software is distributed under the terms and conditions of the 'GNU GENERAL PUBLIC LICENSE
+ * Version 2' license which can be found in the file 'LICENSE.txt' in this package distribution or
+ * at 'http://www.gnu.org/licenses/gpl-2.0-standalone.html'.
+ */
+
 package com.orange.cepheus.mockorion.model;
 
 import org.hibernate.validator.constraints.NotEmpty;


### PR DESCRIPTION
In the files of the mock-iotagent and of the mock-orion ( in the doc directory ), the license headers are missing.
