### PR TITLE
fixed dead link for Esper syntax page

### DIFF
--- a/cepheus-cep/README.md
+++ b/cepheus-cep/README.md
@@ -1,7 +1,7 @@
 # Cepheus-CEP
 
 Cepheus-CEP is a CEP (Complex Event Processor), it uses the [Esper](http://www.espertech.com/esper/) engine.
-This engine provides a lot of features (aggregation, filters, rate limiting, correlation, partitionning...) with a nice [SQL like syntax](http://www.espertech.com/esper/release-5.2.0/esper-reference/html/epl_clauses.html).
+This engine provides a lot of features (aggregation, filters, rate limiting, correlation, partitionning...) with a nice [SQL like syntax](http://www.espertech.com/release-5.2.0/esper-reference/html_single/index.html#epl_clauses).
 
 Goal:
 

--- a/cepheus-cep/README.md
+++ b/cepheus-cep/README.md
@@ -1,7 +1,7 @@
 # Cepheus-CEP
 
 Cepheus-CEP is a CEP (Complex Event Processor), it uses the [Esper](http://www.espertech.com/esper/) engine.
-This engine provides a lot of features (aggregation, filters, rate limiting, correlation, partitionning...) with a nice [SQL like syntax](http://www.espertech.com/release-5.2.0/esper-reference/html_single/index.html#epl_clauses).
+This engine provides a lot of features (aggregation, filters, rate limiting, correlation, partitionning...) with a nice [SQL like syntax](http://esper.espertech.com/release-5.2.0/esper-reference/html/epl_clauses.html).
 
 Goal:
 


### PR DESCRIPTION
I found a dead link for Esper syntax page in fiware-cepheus/cepheus-cep/README.md file.
So, I replaced the link with  link of epl clause reference .