### PR TITLE
Fix for issue #75

### DIFF
--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/SubscriptionManager.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/SubscriptionManager.java
@@ -12,6 +12,7 @@ import com.orange.cepheus.cep.model.Attribute;
 import com.orange.cepheus.cep.model.Configuration;
 import com.orange.cepheus.cep.model.EventTypeIn;
 import com.orange.cepheus.cep.model.Provider;
+import com.orange.cepheus.cep.tenant.TenantFilter;
 import com.orange.ngsi.client.NgsiClient;
 import com.orange.ngsi.model.EntityId;
 import com.orange.ngsi.model.SubscribeContext;
@@ -110,6 +111,9 @@ public class SubscriptionManager {
     private ScheduledFuture scheduledFuture;
 
     private URI hostURI;
+    
+    @Autowired(required=false)
+    TenantFilter tenantFilter;
 
     /**
      * Update subscription to new provider of the incoming events defined in the Configuration
@@ -126,6 +130,14 @@ public class SubscriptionManager {
 
         // Keep a reference to configuration for next migration
         eventTypeIns = configuration.getEventTypeIns();
+        
+        if(tenantFilter!=null){
+            for (EventTypeIn eventType : configuration.getEventTypeIns()) {
+                for (Provider provider : eventType.getProviders()) {
+                	tenantFilter.getClientProviderMap().put(provider.getServiceName()+provider.getServicePath(), configuration.getService()+configuration.getServicePath());
+                }
+            }
+        }
 
         // TODO : send unsubscribeContext with removedEventTypesIn
 

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/tenant/TenantFilter.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/tenant/TenantFilter.java
@@ -53,6 +53,13 @@ public class TenantFilter implements Filter {
      */
     private final ConcurrentMap<String, TenantScope.Context> tenantContexts = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, String> clientProviderMap = new ConcurrentHashMap<>();
+	
+    /**
+    * @return the clientProviderMap
+    */
+    public ConcurrentMap<String, String> getClientProviderMap() {
+	return clientProviderMap;
+    }
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {

--- a/cepheus-cep/src/main/java/com/orange/cepheus/cep/tenant/TenantFilter.java
+++ b/cepheus-cep/src/main/java/com/orange/cepheus/cep/tenant/TenantFilter.java
@@ -52,6 +52,7 @@ public class TenantFilter implements Filter {
      * Map of all the context for each tenant, key: tenantId, a concatenation of service and servicePath
      */
     private final ConcurrentMap<String, TenantScope.Context> tenantContexts = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> clientProviderMap = new ConcurrentHashMap<>();
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -76,7 +77,7 @@ public class TenantFilter implements Filter {
             String servicePath = getServicePath(httpServletRequest);
 
             // Associate the tenant context to the current thread
-            TenantScope.storeTenantContext(getTenantContext(service, servicePath));
+            TenantScope.storeTenantContext(getTenantContext(service, servicePath, httpServletRequest));
 
             // Continue request
             filterChain.doFilter(servletRequest, servletResponse);
@@ -147,6 +148,42 @@ public class TenantFilter implements Filter {
                 }
             }
         }
+        return tenantMap;
+    }
+    
+    /**
+     * Return a tenant context for the given service / servicePath
+     * @param service
+     * @param servicePath
+	 * @param httpServletRequest
+     * @return a tenant context
+     * @throws BadHeaderException 
+     */
+    private TenantScope.Context getTenantContext(String service, String servicePath, HttpServletRequest httpServletRequest) throws BadHeaderException {
+        String tenantId = tenantIdFromService(service, servicePath);
+
+        TenantScope.Context tenantMap = null;
+        if (!httpServletRequest.getRequestURI().startsWith("/v1/admin")) {
+        		tenantMap = tenantContexts.get(clientProviderMap.get(tenantId));
+       }else{
+    	   tenantMap = tenantContexts.get(tenantId);
+           if (tenantMap == null) {
+               synchronized (this) {
+                   tenantMap = tenantContexts.get(tenantId);
+                   if (tenantMap == null) {
+                       tenantMap = new TenantScope.Context();
+                       tenantMap.put(TENANT_ID, tenantId);
+                       if (!DEFAULT_SERVICE.equals(service)) {
+                           tenantMap.put(FIWARE_SERVICE, service);
+                       }
+                       if (!DEFAULT_SERVICE_PATH.equals(servicePath)) {
+                           tenantMap.put(FIWARE_SERVICE_PATH, servicePath);
+                       }
+                       tenantContexts.put(tenantId, tenantMap);
+                   }
+               }
+           }
+       }
         return tenantMap;
     }
 


### PR DESCRIPTION
Updated TenantFilter.java to store a provider's tenant and cepheus's tenant in a map and a overloaded getTenantContext function to update tenantMap based on the request url.

Updated SubscriptionManager.java to put the value the in the map declared in TenantFilter.java

Changes are applicable only for multi-tenant configuration, which can be enabled by un-commenting the line ```spring.profiles.active=multi-tenant``` in ```application.properties```.
